### PR TITLE
Build, test, ship

### DIFF
--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -1,0 +1,145 @@
+name: Build, Test, and Ship
+permissions:
+  contents: read
+on:
+  workflow_call:
+    # TODO: Pass services via inputs.
+    secrets:
+      DEV_AWS_CREDENTIALS:
+        required: true
+      ECR_ACCESS_KEY_ID:
+        required: true
+      ECR_SECRET_ACCESS_KEY:
+        required: true
+      GHA_DEV_KEY:
+        required: true
+      SLACK_BOT_TOKEN:
+        required: true
+
+env:
+  SERVICES: entity entity-updater algolia-updater
+
+jobs:
+  # Retrieve the minimum Go version from go.mod and output a matrix of all Go
+  # versions released since. Skip on release.
+  go-versions:
+    name: Get supported Go versions
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.release }}
+    outputs:
+      matrix: ${{ steps.versions.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set Go versions
+        uses: arnested/go-version-action@v1
+        id: versions
+
+  # Run unit tests and go vet with each supported Go version. Skip on release.
+  unit-test-and-vet:
+    name: "Unit test and vet with Go ${{ matrix.go }}"
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.release }}
+    needs: go-versions
+    strategy:
+      fail-fast: false
+      matrix:
+        go: ${{ fromJSON(needs.go-versions.outputs.matrix) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Test
+        run: |
+          go test -v -cover -race ./...
+
+      - name: Vet
+        run: |
+          go vet ./...
+
+  amazon-ecr:
+    name: "Login to Amazon ECR"
+    runs-on: ubuntu-latest
+    outputs:
+      registry: ${{ steps.login-ecr.outputs.registry }}
+      test: test
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.ECR_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ECR_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Login
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+  # Build the docker image if PR or push to dev/master, ships if Release
+  build-and-ship-image:
+    name: "Build ${{ matrix.service }} image"
+    runs-on: ubuntu-latest
+    needs: amazon-ecr
+    strategy:
+      fail-fast: false
+      matrix:
+        service: ["entity", "entity-updater", "algolia-updater"]
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      # On push/PR, ensure service images can be built on target platforms.
+      - name: Build final images
+        uses: docker/build-push-action@v2
+        if: ${{ !github.event.release }}
+        with:
+          context: .
+          file: ./cmd/${{ matrix.service }}/Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+
+      # On release, build service images and push them to ECR.
+      - name: Build and ship final images
+        uses: docker/build-push-action@v2
+        if: ${{ github.event.release }}
+        env:
+          ECR_REGISTRY: ${{ needs.amazon-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ matrix.service }}
+          IMAGE_TAG: ${{ github.ref_name }}
+        with:
+          context: .
+          file: ./cmd/${{ matrix.service }}/Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
+
+  # Post release status to #deployment.
+  update-slack:
+    name: Update Slack
+    runs-on: ubuntu-latest
+    needs: build-and-ship-image
+    if: ${{ github.event.release }}
+    steps:
+      - name: Post to a Slack channel
+        id: slack
+        uses: slackapi/slack-github-action@v1.17.0
+        with:
+          channel-id: 'C2C5JV162'
+          slack-message: "GitHub has built `${{ github.event.repository.name }}:${{ github.ref_name }}` for release. :shipitparrot: "
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -71,7 +71,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       registry: ${{ steps.login-ecr.outputs.registry }}
-      test: test
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -129,7 +129,9 @@ jobs:
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
+          tags: |
+            ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
+            ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:latest
 
   # Post release status to #deployment.
   update-slack:

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -70,6 +70,7 @@ jobs:
   build-and-ship-image:
     name: "Build ${{ matrix.service }} image"
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     strategy:
       fail-fast: false
       matrix:
@@ -104,10 +105,10 @@ jobs:
           aws-secret-access-key: ${{ secrets.ECR_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
-      - name: Login
+      - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
         if: ${{ github.event.release }}
+        uses: aws-actions/amazon-ecr-login@v1
 
       - name: Build and ship final images
         uses: docker/build-push-action@v2

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -3,7 +3,13 @@ permissions:
   contents: read
 on:
   workflow_call:
-    # TODO: Pass services via inputs.
+    inputs:
+      services:
+        description: >
+          A JSON array containing the names of all services in the repo: the
+          eponymous microservice itself, any associated Kafka consumers, etc.
+        required: true
+        type: string
     secrets:
       DEV_AWS_CREDENTIALS:
         required: true
@@ -15,9 +21,6 @@ on:
         required: true
       SLACK_BOT_TOKEN:
         required: true
-
-env:
-  SERVICES: entity entity-updater algolia-updater
 
 jobs:
   # Retrieve the minimum Go version from go.mod and output a matrix of all Go
@@ -89,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        service: ["entity", "entity-updater", "algolia-updater"]
+        service: ${{ fromJson(inputs.services) }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -66,7 +66,7 @@ jobs:
         run: |
           go vet ./...
 
-  # Build the docker image on PR or push to dev/master, ship on release
+  # Build the docker images on PR or push to dev/master, ship on release
   build-and-ship-image:
     name: "Build ${{ matrix.service }} image"
     runs-on: ubuntu-latest
@@ -85,7 +85,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      # On push/PR, ensure service image can be built on target platforms.
+      # On push/PR, ensure service images can be built on target platforms.
       - name: Build final images
         uses: docker/build-push-action@v2
         if: ${{ !github.event.release }}
@@ -96,7 +96,7 @@ jobs:
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
 
-      # On release, build service image and push to ECR.
+      # On release, build service images and push to ECR.
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         if: ${{ github.event.release }}

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -66,7 +66,7 @@ jobs:
         run: |
           go vet ./...
 
-  # Build the docker image if PR or push to dev/master, ships if Release
+  # Build the docker image on PR or push to dev/master, ship on release
   build-and-ship-image:
     name: "Build ${{ matrix.service }} image"
     runs-on: ubuntu-latest
@@ -85,7 +85,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      # On push/PR, ensure service images can be built on target platforms.
+      # On push/PR, ensure service image can be built on target platforms.
       - name: Build final images
         uses: docker/build-push-action@v2
         if: ${{ !github.event.release }}
@@ -96,7 +96,7 @@ jobs:
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
 
-      # On release, build service images and push them to ECR.
+      # On release, build service image and push to ECR.
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         if: ${{ github.event.release }}

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -66,28 +66,10 @@ jobs:
         run: |
           go vet ./...
 
-  amazon-ecr:
-    name: "Login to Amazon ECR"
-    runs-on: ubuntu-latest
-    outputs:
-      registry: ${{ steps.login-ecr.outputs.registry }}
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.ECR_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.ECR_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-
-      - name: Login
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-
   # Build the docker image if PR or push to dev/master, ships if Release
   build-and-ship-image:
     name: "Build ${{ matrix.service }} image"
     runs-on: ubuntu-latest
-    needs: amazon-ecr
     strategy:
       fail-fast: false
       matrix:
@@ -114,6 +96,19 @@ jobs:
           platforms: linux/amd64,linux/arm64
 
       # On release, build service images and push them to ECR.
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        if: ${{ github.event.release }}
+        with:
+          aws-access-key-id: ${{ secrets.ECR_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ECR_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Login
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+        if: ${{ github.event.release }}
+
       - name: Build and ship final images
         uses: docker/build-push-action@v2
         if: ${{ github.event.release }}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
-# back-end-actions
+# Back-end Actions
+
+This repo contains [GitHub Actions](https://docs.github.com/en/actions)
+workflows/actions shared across our back-end services. This repo is designed
+only for internal use but must be public due to current limitations on [reusable
+workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows#access-to-reusable-workflows).


### PR DESCRIPTION
cc @bnsfrt 

### Documentation

- [Asana task](https://app.asana.com/0/1201453510342377/1202262750520682/f)

### Description

This PR factors out the `buildTestShip.yaml` GHA workflow files from our various back-end repos (e.g. [in `entity`](https://github.com/nicheinc/entity/blob/dev/.github/workflows/buildTestShip.yaml)) into a reusable (and therefore public) workflow. The only intended substantive change in behavior from the existing workflows is that the new workflow builds and pushes a `latest` docker image tag to ECR, in addition to the semver tags we currently push. We can use these `latest` images in CI and in the `development` repo's `docker-compose.yml` ([Asana task](https://app.asana.com/0/1199932090708798/1202699911962363/f)) to make it easier/more transparent to pull latest service images.

For ease of review, here is the diff between the `jobs` section of the current `buildTestShip.yaml` and the `build-test-ship.yaml` in this PR:
```diff jobs:
-  # Retrieves Go version from go.mod and returns all Go versions released since
-  # if PR or push to dev/master
+  # Retrieve the minimum Go version from go.mod and output a matrix of all Go
+  # versions released since. Skip on release.
   go-versions:
-    name: Check Go versions
+    name: Get supported Go versions
     runs-on: ubuntu-latest
     if: ${{ !github.event.release }}
     outputs:
@@ -41,12 +38,10 @@ jobs:
       - name: Set Go versions
         uses: arnested/go-version-action@v1
         id: versions
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Run unit tests and go vet with each Go version returned from go-versions job
-  # if PR or push to dev/master
+  # Run unit tests and go vet with each supported Go version. Skip on release.
   unit-test-and-vet:
+    name: "Unit test and vet with Go ${{ matrix.go }}"
     runs-on: ubuntu-latest
     if: ${{ !github.event.release }}
     needs: go-versions
@@ -54,7 +49,6 @@ jobs:
       fail-fast: false
       matrix:
         go: ${{ fromJSON(needs.go-versions.outputs.matrix) }}
-    name: "Unit test and vet with (${{ matrix.go }})"
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -72,18 +66,16 @@ jobs:
         run: |
           go vet ./...
 
-  # Builds the docker image if PR or push to dev/master,
-  # ships if Release
+  # Build the docker image on PR or push to dev/master, ship on release
   build-and-ship-image:
+    name: "Build ${{ matrix.service }} image"
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft }}
     strategy:
       fail-fast: false
       matrix:
-        service: ["entity", "entity-updater", "algolia-updater"]
-    name: "Build ${{ matrix.service }} image"
+        service: ${{ fromJson(inputs.services) }}
     steps:
-      ### Common steps
       - name: Checkout Repo
         uses: actions/checkout@v2
 
@@ -93,7 +85,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Build final image
+      # On push/PR, ensure service image can be built on target platforms.
+      - name: Build final images
         uses: docker/build-push-action@v2
         if: ${{ !github.event.release }}
         with:
@@ -103,7 +96,7 @@ jobs:
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
 
-      ### Release-specific steps
+      # On release, build service image and push to ECR.
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         if: ${{ github.event.release }}
@@ -117,12 +110,11 @@ jobs:
         if: ${{ github.event.release }}
         uses: aws-actions/amazon-ecr-login@v1
 
-        # Builds images and ships them to ECR
-      - name: Build and ship final image
+      - name: Build and ship final images
         uses: docker/build-push-action@v2
         if: ${{ github.event.release }}
         env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REGISTRY: ${{ needs.amazon-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ matrix.service }}
           IMAGE_TAG: ${{ github.ref_name }}
         with:
@@ -132,10 +124,13 @@ jobs:
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ env.ECR_REGISTRY}}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
+          tags: |
+            ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
+            ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:latest
 
-  # Post release status to #deployment
+  # Post release status to #deployment.
   update-slack:
+    name: Update Slack
     runs-on: ubuntu-latest
     needs: build-and-ship-image
     if: ${{ github.event.release }}
@@ -147,4 +142,4 @@ jobs:
           channel-id: 'C2C5JV162'
           slack-message: "GitHub has built `${{ github.event.repository.name }}:${{ github.ref_name }}` for release. :shipitparrot: "
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
\ No newline at end of file
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
```

### Testing Considerations

This workflow will be tested via its use in the `entity` repo: https://github.com/nicheinc/entity/pull/247. It does not require QA.

### Deployment 

This is a workflow, so merged = deployed. After this is merged and the associated `entity` PR is approved, we should change the `entity` workflow file to point to `@main` instead of `@feature/build-test-ship` before merging that PR.

### Versioning

~~Probably v0.1.0?~~ For now, I've pointed the back-end repos `@main`. Not sure if we want to tag releases in this repo at all. If we eventually have multiple workflows in this repo, versioning could get a little hairy, so I'm inclined to just let `main` be the target for "released" workflows.
