### PR TITLE
Run API Proctor tests in build-ship-test

### DIFF
--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -231,15 +231,27 @@ jobs:
       - name: Download docker image artifacts
         uses: actions/download-artifact@v3
 
-      - name: Parse services into a space-separated string
-        id: parse-services
+      - name: Set up yq for YAML processing
+        uses: mikefarah/yq@v4.27.3
+
+      - name: Get relevant services as a space-separated string
+        id: get-services
         shell: bash
-        run: echo "services=`jq -r 'join(" ")' <<< '${{ inputs.services }}'`" >> $GITHUB_OUTPUT
+        run: |
+          tools=`yq -o=json '.services
+            | with_entries(select(.value.profiles.[] | contains("tools")))
+            | to_entries
+            | map(.key)' docker-compose.yml`
+          all_services=`yq -o=json '.services | keys' docker-compose.yml`
+          non_tools=`jq --null-input "${all_services} - ${tools}"`
+          input_services='${{ inputs.services }}'
+          services=`jq --null-input "${input_services} - (${input_services} - ${non_tools})"`
+          echo "services=`jq -r 'join(" ")' <<< ${services}`" >> $GITHUB_OUTPUT
 
       - name: Load docker images
         shell: bash
         run: |
-          for service in ${{ steps.parse-services.outputs.services }}; do
+          for service in ${{ steps.get-services.outputs.services }}; do
             docker load --input ${service}/${service}.tar
           done
 
@@ -260,16 +272,13 @@ jobs:
       - name: Use latest service images from ECR
         run: sed -i 's/${USER:?USER}/${{ steps.login-ecr.outputs.registry }}/' docker-compose.yml
 
-      - name: Set up yq for YAML processing
-        uses: mikefarah/yq@v4.27.3
-
       - name: Create docker-compose override and AWS credentials files
         env:
           ENCODED_CREDENTIALS: ${{ secrets.DEV_AWS_CREDENTIALS }}
         shell: bash
         run: |
           yq -n ".version = \"3.7\"" > docker-compose.override.yaml
-          for service in ${{ steps.parse-services.outputs.services }}; do
+          for service in ${{ steps.get-services.outputs.services }}; do
             yq -i ".services.${service}.image = \"${service}:ci\"" docker-compose.override.yaml
           done
           echo docker-compose.override.yaml:
@@ -292,7 +301,7 @@ jobs:
           declare -A work_set # Nodes to be visited
           declare -A deps # Nodes already in the dependency set
           # Initialize the work set to the services from this repo.
-          for service in ${{ steps.parse-services.outputs.services }}; do
+          for service in ${{ steps.get-services.outputs.services }}; do
             work_set[${service}]=1
           done
           # While the work set is nonempty, pop and visit an arbitrary node.
@@ -353,8 +362,8 @@ jobs:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         shell: bash
         run: |
-          docker-compose pull --include-deps ${{ steps.parse-services.outputs.services }}
-          docker-compose up -d ${{ steps.parse-services.outputs.services }}
+          docker-compose pull --include-deps ${{ steps.get-services.outputs.services }}
+          docker-compose up -d ${{ steps.get-services.outputs.services }}
 
       - name: Run API Proctor tests
         env:
@@ -372,7 +381,7 @@ jobs:
         if: success() || failure()
         shell: bash
         run: |
-          for service in ${{ steps.parse-services.outputs.services }}; do
+          for service in ${{ steps.get-services.outputs.services }}; do
             echo "::group::${service} logs"
             docker-compose logs ${service}
             echo "::endgroup::"

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -233,7 +233,7 @@ jobs:
             # Start postgres in docker and create database and role.
             docker-compose up -d postgres
             docker-compose logs postgres
-            docker exec -i postgres psql -U ${POSTGRES_USER} -c \
+            docker exec -i postgres psql -h ${POSTGRES_SERVER} -U ${POSTGRES_USER} -c \
               "CREATE DATABASE ${db}; CREATE ROLE ${username} LOGIN PASSWORD '${password}'"
           done
 

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -263,12 +263,9 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         shell: bash
         run: |
-          docker run \
-            --rm \
-            --name api-proctor \
-            --network host \
+          docker run --rm --name api-proctor --network host \
             $ECR_REGISTRY/api-proctor:v1.3.0 \
-            ${{ github.event.repository.name }}/health.get --testPathIgnorePatterns=/src/ --passWithNoTests
+            ${{ github.event.repository.name }} --testPathIgnorePatterns=/src/ --passWithNoTests
 
       - name: Docker Compose logs
         shell: bash

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -216,10 +216,12 @@ jobs:
           touch vault/website.secrets.env
           touch vault/landingpageadmin.secrets.env
 
-      - name: Create service databases and roles
+      - name: Start postgres and create service databases and roles
         shell: bash
         run: |
-          # Parse unique usernames, passwords, and DBs from POSTGRES_CONNECTION strings.
+          docker-compose up -d postgres
+          # Parse usernames, passwords, and DBs from POSTGRES_CONNECTION
+          # strings, deduplicated by username.
           declare -A db_info
           while read -r line; do
             regex='postgres://(\w*):(\w*)@\$\{POSTGRES_SERVER\}/(\w*)'
@@ -228,11 +230,11 @@ jobs:
               db_info[${BASH_REMATCH[1]}]=${BASH_REMATCH[@]:2:2}
             fi
           done < <(grep POSTGRES_CONNECTION docker-compose.yml)
+          # Wait for postgres to accept connections
+          timeout 1m bash -c 'until docker-compose run postgres pg_isready -d postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres; do sleep 5s; done'
+          # Create databases and roles
           for username in "${!db_info[@]}"; do
             read -r password db <<<$(echo ${db_info[${username}]})
-            # Start postgres in docker and create database and role.
-            docker-compose up -d postgres
-            docker-compose logs postgres
             docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres psql -h 0.0.0.0 -U ${POSTGRES_USER} -c \
               "CREATE DATABASE ${db}"
             docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres psql -h 0.0.0.0 -U ${POSTGRES_USER} -c \

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -266,8 +266,8 @@ jobs:
           docker run --rm --name api-proctor --network host \
             -e READ_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
             -e WRITE_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
-            $ECR_REGISTRY/api-proctor:v1.3.0 \
-            tests/${{ github.event.repository.name }}/v3.entity.get.test.ts --testPathIgnorePatterns=/src/ --passWithNoTests
+            $ECR_REGISTRY/api-proctor:latest \
+            tests/${{ github.event.repository.name }} --testPathIgnorePatterns=/src/ --passWithNoTests
 
       - name: Docker Compose logs
         shell: bash

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -198,7 +198,8 @@ jobs:
       matrix:
         service: ${{ fromJson(inputs.services) }}
     if: |
-      github.event_name == 'pull_request' ||
+      (github.event_name == 'pull_request' &&
+        !github.event.pull_request.draft) ||
       (github.event_name == 'push' &&
         steps.check-version-change.outputs.appchange == 'false')
     steps:

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -10,6 +10,10 @@ on:
           eponymous microservice itself, any associated Kafka consumers, etc.
         required: true
         type: string
+      api-proctor-timeout-minutes:
+        description: The timeout in minutes for running API Proctor tests.
+        default: 30
+        type: number
     secrets:
       DEV_AWS_CREDENTIALS:
         required: true
@@ -150,6 +154,7 @@ jobs:
     name: Run api-proctor tests
     runs-on: ubuntu-latest
     needs: build-and-ship-image
+    timeout-minutes: ${{ inputs.api-proctor-timeout-minutes }}
     env:
       PGADMIN_PORT: 5000
       POSTGRES_USER: postgres

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -234,7 +234,7 @@ jobs:
             docker-compose up -d postgres
             docker-compose logs postgres
             docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres psql -h 0.0.0.0 -U ${POSTGRES_USER} -c \
-              "\set AUTOCOMMIT on; CREATE DATABASE ${db}; CREATE ROLE ${username} LOGIN PASSWORD '${password}'"
+              "CREATE DATABASE ${db}; COMMIT; CREATE ROLE ${username} LOGIN PASSWORD '${password}'; COMMIT"
           done
 
       - name: Launch services with dependencies via docker-compose

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -193,6 +193,7 @@ jobs:
         run: |
           echo Services: ${{ steps.parse-services.outputs.services }}
           for service in ${{ steps.parse-services.outputs.services }}; do
+            echo Loading service: ${service}
             docker load --input ${service}/${service}.tar
           done
 

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -238,15 +238,13 @@ jobs:
             # unvisited dependencies to the work set.
             echo Visiting ${next}...
             deps[${next}]=1
-            next_deps=$(yq ".services.${next}.depends_on" docker-compose.yml | sort | uniq)
-            if [[ ${next_deps} != null ]]; then
-              for next_dep in ${next_deps}; do
-                echo ...depends on ${next_dep}
-                if [[ ! ${deps[${next_dep}]} ]]; then
-                  work_set[${next_dep}]=1
-                fi
-              done
-            fi
+            next_deps=$(yq ".services.${next}.depends_on[]" docker-compose.yml | sort | uniq)
+            for next_dep in ${next_deps}; do
+              echo ...depends on ${next_dep}
+              if [[ ! ${deps[${next_dep}]} ]]; then
+                work_set[${next_dep}]=1
+              fi
+            done
           done
           echo Dependencies: ${!deps[@]}
           echo "::set-output name=deps::${!deps[@]}"

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -267,7 +267,7 @@ jobs:
             -e READ_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
             -e WRITE_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
             $ECR_REGISTRY/api-proctor:latest \
-            tests/${{ github.event.repository.name }}/ --testPathIgnorePatterns=/src/ --passWithNoTests
+            tests/${{ github.event.repository.name }}/health.get --testPathIgnorePatterns=/src/ --passWithNoTests
 
       - name: Docker Compose logs
         shell: bash

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -265,7 +265,7 @@ jobs:
         run: |
           docker run --rm --name api-proctor --network host \
             $ECR_REGISTRY/api-proctor:v1.3.0 \
-            ${{ github.event.repository.name }} --testPathIgnorePatterns=/src/ --passWithNoTests
+            tests/${{ github.event.repository.name }}/ --testPathIgnorePatterns=/src/ --passWithNoTests
 
       - name: Docker Compose logs
         shell: bash

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -102,16 +102,17 @@ jobs:
           path: ${{ matrix.service }}.tar
           retention-days: 1
 
+      # TODO: Disabled for development. Reenable before this branch is merged.
       # On push/PR, ensure service images can be built on target platforms.
-      - name: Build final images
-        uses: docker/build-push-action@v2
-        if: ${{ !github.event.release }}
-        with:
-          context: .
-          file: ./cmd/${{ matrix.service }}/Dockerfile
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
+      # - name: Build final images
+      #  uses: docker/build-push-action@v2
+      #  if: ${{ !github.event.release }}
+      #  with:
+      #    context: .
+      #    file: ./cmd/${{ matrix.service }}/Dockerfile
+      #    cache-from: type=gha
+      #    cache-to: type=gha,mode=max
+      #    platforms: linux/amd64,linux/arm64
 
       # On release, build service images and push to ECR.
       - name: Configure AWS credentials

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -150,9 +150,10 @@ jobs:
       - name: Print github.event context value for debugging
         shell: bash
         run: |
-          echo ${{ github.event }}
-          echo ${{ github.event.pull_request }}
-          echo ${{ github.event.pull_request.draft }}
+          echo Event name: ${{ github.event_name }}
+          echo github.event: ${{ github.event }}
+          echo github.event.pull_request: ${{ github.event.pull_request }}
+          echo github.event.pull_request.draft: ${{ github.event.pull_request.draft }}
 
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -254,7 +254,7 @@ jobs:
         run: |
           pwd
           docker-compose up -d postgres
-          timeout 1m bash -c 'until docker-compose run postgres pg_isready -d postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres; do sleep 5s; done'
+          timeout 1m bash -c 'until docker-compose run postgres pg_isready -d postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres; do sleep 1s; done'
           declare -A dbs
           declare -A roles
           conn_regex='postgres://(\w*):(\w*)@\$\{POSTGRES_SERVER\}/(\w*)'

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -272,8 +272,9 @@ jobs:
                 context=$(yq ".services.${dependency}.build.context" docker-compose.yml)
                 extensions="${context}/sql/extensions.sql"
                 if [[ -f ${extensions} ]]; then
+                  docker compose cp ${extensions} postgres:extensions.sql
                   docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres \
-                    psql -h 0.0.0.0 -U ${POSTGRES_USER} -d ${db} -a -f ${extensions}
+                    psql -h 0.0.0.0 -U ${POSTGRES_USER} -d ${db} -a -f extensions.sql
                 fi
               else
                 echo ${db} database already initialized

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -105,10 +105,10 @@ jobs:
               chartchange="false"
             fi
           done
-          echo "::set-output name=appversion::${APPVERSION}"
-          echo "::set-output name=chartversion::${CHARTVERSION}"
-          echo "::set-output name=appchange::${appchange}"
-          echo "::set-output name=chartchange::${chartchange}"
+          echo "appversion=${APPVERSION}" >> $GITHUB_OUTPUT
+          echo "chartversion=${CHARTVERSION}" >> $GITHUB_OUTPUT
+          echo "appchange=${appchange}" >> $GITHUB_OUTPUT
+          echo "chartchange=${chartchange}" >> $GITHUB_OUTPUT
 
       # On merge to dev make sure if the app changed
       # but the chart version didn't we error out
@@ -234,7 +234,7 @@ jobs:
       - name: Parse services into a space-separated string
         id: parse-services
         shell: bash
-        run: echo "::set-output name=services::`jq -r 'join(" ")' <<< '${{ inputs.services }}'`"
+        run: echo "services=`jq -r 'join(" ")' <<< '${{ inputs.services }}'`" >> $GITHUB_OUTPUT
 
       - name: Load docker images
         shell: bash
@@ -311,7 +311,7 @@ jobs:
             done
           done
           echo Dependencies: ${!deps[@]}
-          echo "::set-output name=deps::${!deps[@]}"
+          echo "deps=${!deps[@]}" >> $GITHUB_OUTPUT
 
       - name: Start postgres and create service databases and roles
         shell: bash

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -216,6 +216,18 @@ jobs:
           touch vault/website.secrets.env
           touch vault/landingpageadmin.secrets.env
 
+      - name: Set up yq for YAML processing
+        uses: mikefarah/yq@v4.27.3
+
+      - name: Parse service dependencies
+        id: parse-deps
+        run: |
+          keys=(${{ steps.parse-services.outputs.services }})
+          keys=${keys[@]/#/.}
+          keys=${keys// /,}
+          deps=$(yq ".services | (${keys}) | .depends_on" docker-compose.yml | sort | uniq)
+          echo "::set-output name=dependencies::$deps"
+
       - name: Start postgres and create service databases and roles
         shell: bash
         run: |

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -223,6 +223,10 @@ jobs:
           docker-compose pull
           docker-compose -f docker-compose.yml -f docker-compose.ci.yaml up -d ${{ steps.parse-services.outputs.services }}
 
+      - name: View entity logs, for debugging
+        shell: bash
+        run: docker-compose logs entity
+
       - name: API Proctor health check test
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -195,6 +195,15 @@ jobs:
             docker load --input ${service}/${service}.tar
           done
 
+      - name: Set up yq for YAML processing
+        uses: mikefarah/yq@v4.27.3
+
+      # We only use docker-compose.yml for its dependency graph, not for build
+      # configuration. Since we don't check out submodules, we need to remove
+      # any references to submodule files.
+      - name: Trim down docker-compose.yml
+        run: yq -i 'del(.services.*.build, .services.*.env_file)' docker-compose.yml
+
       - name: Create docker-compose override and AWS credentials files
         env:
           ENCODED_CREDENTIALS: ${{ secrets.DEV_AWS_CREDENTIALS }}

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -226,31 +226,45 @@ jobs:
           keys=${keys[@]/#/.}
           keys=${keys// /,}
           deps=$(yq ".services | (${keys}) | .depends_on" docker-compose.yml | sort | uniq)
-          echo "::set-output name=dependencies::$deps"
+          echo "::set-output name=deps::$deps"
 
       - name: Start postgres and create service databases and roles
         shell: bash
         run: |
           docker-compose up -d postgres
-          # Parse usernames, passwords, and DBs from POSTGRES_CONNECTION
-          # strings, deduplicated by username.
-          declare -A db_info
-          while read -r line; do
-            regex='postgres://(\w*):(\w*)@\$\{POSTGRES_SERVER\}/(\w*)'
-            if [[ ${line} =~ ${regex} ]]; then
-              # Map username to the associated password and DB.
-              db_info[${BASH_REMATCH[1]}]=${BASH_REMATCH[@]:2:2}
-            fi
-          done < <(grep POSTGRES_CONNECTION docker-compose.yml)
-          # Wait for postgres to accept connections
           timeout 1m bash -c 'until docker-compose run postgres pg_isready -d postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres; do sleep 5s; done'
-          # Create databases and roles
-          for username in "${!db_info[@]}"; do
-            read -r password db <<<$(echo ${db_info[${username}]})
-            docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres psql -h 0.0.0.0 -U ${POSTGRES_USER} -c \
-              "CREATE DATABASE ${db}"
-            docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres psql -h 0.0.0.0 -U ${POSTGRES_USER} -c \
-              "CREATE ROLE ${username} LOGIN PASSWORD '${password}'"
+          declare -A dbs
+          declare -A roles
+          conn_regex='postgres://(\w*):(\w*)@\$\{POSTGRES_SERVER\}/(\w*)'
+          for dependency in ${{ steps.parse-deps.outputs.deps }}; do
+            # Parse role, password, and DB from POSTGRES_CONNECTION.
+            conn=$(yq ".services.${dependency}.environment.POSTGRES_CONNECTION" docker-compose.yml)
+            if [[ ${conn} =~ ${conn_regex} ]]; then
+              role=${BASH_REMATCH[1]}
+              password=${BASH_REMATCH[2]}
+              db=${BASH_REMATCH[3]}
+              if [[ ! ${dbs[${db}]} ]]; then
+                dbs[${db}]=1
+                docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres \
+                  psql -h 0.0.0.0 -U ${POSTGRES_USER} -a -c "CREATE DATABASE ${db}"
+                context=$(yq ".services.${dependency}.build.context" docker-compose.yml)
+                extensions="${context}/sql/extensions.sql"
+                if [[ test -f ${extensions} ]]; then
+                  docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres \
+                    psql -h 0.0.0.0 -U ${POSTGRES_USER} -d ${db} -a -f ${extensions}
+                fi
+              else
+                echo ${db} database already initialized
+              fi
+              if [[ ! ${roles[${role}]} ]]; then
+                roles[${role}]=1
+                docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres \
+                  psql -h 0.0.0.0 -U ${POSTGRES_USER} -a -c \
+                  "CREATE ROLE ${role} LOGIN PASSWORD '${password}'"
+              else
+                echo ${role} role already exists
+              fi
+            fi
           done
 
       - name: Launch services with dependencies via docker-compose

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -220,8 +220,9 @@ jobs:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         shell: bash
         run: |
+          docker-compose pull --include-deps ${{ steps.parse-services.outputs.services }}
           docker-compose -f docker-compose.yml -f docker-compose.ci.yaml \
-            up -d --pull always ${{ steps.parse-services.outputs.services }}
+            up -d ${{ steps.parse-services.outputs.services }}
 
       - name: View entity logs, for debugging
         shell: bash

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -270,7 +270,7 @@ jobs:
           docker run --rm --name api-proctor --network host \
             -e READ_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
             -e WRITE_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
-            $ECR_REGISTRY/api-proctor:pr-experiment-remove-common-tests \
+            $ECR_REGISTRY/api-proctor:pr-x-push-node-env-ci \
             tests/${{ github.event.repository.name }}/health.get --testPathIgnorePatterns=/src/ --passWithNoTests
 
       - name: Docker Compose logs

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -222,11 +222,29 @@ jobs:
       - name: Parse service dependencies
         id: parse-deps
         run: |
-          keys=(${{ steps.parse-services.outputs.services }})
-          keys=${keys[@]/#/.}
-          keys=${keys// /,}
-          deps=$(yq ".services | (${keys}) | .depends_on" docker-compose.yml | sort | uniq)
-          echo "::set-output name=deps::$deps"
+          # Traverse depends_on values to build the unified dependency set.
+          declare -A work_set # Nodes to be visited
+          declare -A deps # Nodes already in the dependency set
+          # Initialize the work set to the services from this repo.
+          for service in ${{ steps.parse-services.outputs.services }}; do
+            work_set[${service}]=1
+          done
+          # While the work set is nonempty, pop and visit an arbitrary node.
+          while [[ ${#work_set[@]} -gt 0 ]]; do
+            keys=(${!work_set[@]})
+            next=${keys[0]}
+            unset work_set[${next}]
+            # Add the next node to the dependency set, and add any of its
+            # unvisited dependencies to the work set.
+            deps[${next}]=1
+            next_deps=$(yq ".services.${next}.depends_on" docker-compose.yml | sort | uniq)
+            for next_dep in ${next_deps}; do
+              if [[ ! ${deps[${next_dep}]} ]]; do
+                work_set[${next_dep}]=1
+              done
+            done
+          done
+          echo "::set-output name=deps::${!deps[@]}"
 
       - name: Start postgres and create service databases and roles
         shell: bash

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -266,7 +266,7 @@ jobs:
           docker run --rm --name api-proctor --network host \
             -e READ_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
             -e WRITE_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
-            $ECR_REGISTRY/api-proctor:latest \
+            $ECR_REGISTRY/api-proctor:dev-19dea32 \
             tests/${{ github.event.repository.name }}/health.get --testPathIgnorePatterns=/src/ --passWithNoTests
 
       - name: Docker Compose logs

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -223,16 +223,17 @@ jobs:
           declare -A db_info
           while read -r line; do
             regex='postgres://(\w*):(\w*)@\$\{POSTGRES_SERVER\}/(\w*)'
-            if [[ $line =~ $regex ]]; then
+            if [[ ${line} =~ ${regex} ]]; then
               # Map username to the associated password and DB.
               db_info[${BASH_REMATCH[1]}]=${BASH_REMATCH[@]:2:2}
             fi
           done < <(grep POSTGRES_CONNECTION docker-compose.yml)
           for username in "${!db_info[@]}"; do
-            read -r password db <<<$(echo ${db_info[$username]})
-            # Create database and role.
-            psql -c "CREATE DATABASE IF NOT EXISTS $db"
-            psql -c "CREATE ROLE $username LOGIN PASSWORD $password"
+            read -r password db <<<$(echo ${db_info[${username}]})
+            # Start postgres in docker and create database and role.
+            docker-compose up -d postgres
+            docker exec -i postgres psql -U ${POSTGRES_USER} -c \
+              "CREATE DATABASE ${db}; CREATE ROLE ${username} LOGIN PASSWORD '${password}'"
           done
 
       - name: Launch services with dependencies via docker-compose

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -239,9 +239,9 @@ jobs:
             deps[${next}]=1
             next_deps=$(yq ".services.${next}.depends_on" docker-compose.yml | sort | uniq)
             for next_dep in ${next_deps}; do
-              if [[ ! ${deps[${next_dep}]} ]]; do
+              if [[ ! ${deps[${next_dep}]} ]]; then
                 work_set[${next_dep}]=1
-              done
+              fi
             done
           done
           echo "::set-output name=deps::${!deps[@]}"

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -220,8 +220,8 @@ jobs:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         shell: bash
         run: |
-          docker-compose pull
-          docker-compose -f docker-compose.yml -f docker-compose.ci.yaml up -d ${{ steps.parse-services.outputs.services }}
+          docker-compose -f docker-compose.yml -f docker-compose.ci.yaml \
+            up -d ${{ steps.parse-services.outputs.services }}
 
       - name: View entity logs, for debugging
         shell: bash

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -17,7 +17,7 @@ on:
         required: true
       ECR_SECRET_ACCESS_KEY:
         required: true
-      GHA_DEV_KEY:
+      NPM_WRITE_TOKEN:
         required: true
       SLACK_BOT_TOKEN:
         required: true
@@ -178,7 +178,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: nicheinc/development
-          ssh-key: ${{ secrets.GHA_DEV_KEY }}
+          token: ${{ secrets.NPM_WRITE_TOKEN }}
+          submodules: true
 
       - name: Download docker image artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -220,8 +220,8 @@ jobs:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         shell: bash
         run: |
-          docker-compose --pull always -f docker-compose.yml -f docker-compose.ci.yaml \
-            up -d ${{ steps.parse-services.outputs.services }}
+          docker-compose -f docker-compose.yml -f docker-compose.ci.yaml \
+            up -d --pull always ${{ steps.parse-services.outputs.services }}
 
       - name: View entity logs, for debugging
         shell: bash

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -244,6 +244,7 @@ jobs:
               fi
             done
           done
+          echo Dependencies: ${!deps[@]}
           echo "::set-output name=deps::${!deps[@]}"
 
       - name: Start postgres and create service databases and roles

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -267,7 +267,7 @@ jobs:
             -e READ_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
             -e WRITE_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
             $ECR_REGISTRY/api-proctor:latest \
-            tests/${{ github.event.repository.name }}/does-not-exist --testPathIgnorePatterns=/src/ --passWithNoTests
+            tests/${{ github.event.repository.name }}/ --testPathIgnorePatterns=/src/ --passWithNoTests
 
       - name: Docker Compose logs
         shell: bash

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -210,7 +210,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
 
   run-api-proctor-tests:
-    name: Run api-proctor tests
+    name: Run API Proctor tests
     runs-on: ubuntu-latest
     needs: build-and-ship-images
     timeout-minutes: ${{ inputs.api-proctor-timeout-minutes }}

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -234,7 +234,7 @@ jobs:
             docker-compose up -d postgres
             docker-compose logs postgres
             docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres psql -h 0.0.0.0 -U ${POSTGRES_USER} -c \
-              "CREATE DATABASE ${db}; CREATE ROLE ${username} LOGIN PASSWORD '${password}'"
+              "\set AUTOCOMMIT on; CREATE DATABASE ${db}; CREATE ROLE ${username} LOGIN PASSWORD '${password}'"
           done
 
       - name: Launch services with dependencies via docker-compose

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -213,6 +213,15 @@ jobs:
           done
           echo $ENCODED_CREDENTIALS | base64 -di > vault/aws_credentials
 
+      # TODO: This is a hack to place empty secret files in the vault directory
+      # (to satisfy docker-compose.yml requirements) without actually retrieving
+      # them from vault.
+      - name: Retrieve vault secrets
+        shell: bash
+        run: |
+          touch vault/website.secrets.env
+          touch vault/landingpageadmin.secrets.env
+
       - name: Launch service with dependencies in docker-compose
         env:
           REGISTRY: ${{ needs.amazon-ecr.outputs.registry }}

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -66,11 +66,28 @@ jobs:
         run: |
           go vet ./...
 
-  # Build the docker images on PR or push to dev/master, ship on release
+  amazon-ecr:
+    name: "Login to Amazon ECR"
+    runs-on: ubuntu-latest
+    outputs:
+      registry: ${{ steps.login-ecr.outputs.registry }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.ECR_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ECR_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Login
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+  # Build the docker images on PR or push to dev/master, ship on release.
   build-and-ship-image:
     name: "Build ${{ matrix.service }} image"
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.draft }}
+    needs: amazon-ecr
     strategy:
       fail-fast: false
       matrix:
@@ -84,6 +101,24 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+
+      # Build and upload image artifact for use in api-proctor tests.
+      - name: Build image for CI
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./cmd/${{ matrix.service }}/Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          outputs: type=docker,dest=${{ matrix.service }}.tar
+          tags: ${{ matrix.service }}:ci
+
+      - name: Upload docker image artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.service }}
+          path: ${{ matrix.service }}.tar
+          retention-days: 1
 
       # On push/PR, ensure service images can be built on target platforms.
       - name: Build final images
@@ -127,6 +162,76 @@ jobs:
           tags: |
             ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
             ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:latest
+
+  run-api-proctor-tests:
+    name: Run api-proctor tests
+    runs-on: ubuntu-latest
+    needs: [amazon-ecr, build-and-ship-image]
+    env:
+      PGADMIN_PORT: 5000
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_SERVER: postgres
+      POSTGRES_PORT: 5432
+    steps:
+      - name: Checkout development repo
+        uses: actions/checkout@v2
+        with:
+          repository: nicheinc/development
+          ssh-key: ${{ secrets.GHA_DEV_KEY }}
+
+      - name: Download docker image artifacts
+        uses: actions/download-artifact@v3
+
+      - name: Load docker images
+        shell: bash
+        run: |
+          for service in ${SERVICES}; do
+            docker load --input ${service}/${service}.tar
+          done
+
+      - name: Create docker-compose override and AWS credentials files
+        env:
+          ENCODED_CREDENTIALS: ${{ secrets.DEV_AWS_CREDENTIALS }}
+        shell: bash
+        run: |
+          echo "services:" >> docker-compose.ci.yaml
+          for service in ${SERVICES}; do
+            echo -e "  ${service}:\n    image: ${service}:ci" >> docker-compose.ci.yaml
+          done
+          echo $ENCODED_CREDENTIALS | base64 -di > vault/aws_credentials
+
+      - name: Launch service with dependencies in docker-compose
+        env:
+          REGISTRY: ${{ needs.amazon-ecr.outputs.registry }}
+        shell: bash
+        run: docker-compose -f docker-compose.yml -f docker-compose.ci.yaml up -d ${SERVICES}
+
+      - name: api-proctor health check test
+        env:
+          ECR_REGISTRY: ${{ needs.amazon-ecr.outputs.registry }}
+        shell: bash
+        run: |
+          docker run \
+            --rm \
+            --name api-proctor \
+            --network host \
+            $ECR_REGISTRY/api-proctor:v1.3.0 \
+            ${{ github.event.repository.name }}/health.get --testPathIgnorePatterns=/src/ --passWithNoTests
+
+      - name: Docker Compose logs
+        shell: bash
+        run: |
+          echo "::group::Docker ${{ github.event.repository.name }} logs"
+          echo "--- Kafka logs ---"
+          docker-compose logs kafka || echo "Kafka not running"
+          echo "--- Postgres logs ---"
+          docker-compose logs postgres || echo "Postgres not running"
+          for service in ${SERVICES}; do
+            echo "--- ${service} logs ---"
+            docker-compose logs ${service}
+          done
+          echo "::endgroup::"
 
   # Post release status to #deployment.
   update-slack:

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -267,7 +267,7 @@ jobs:
             -e READ_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
             -e WRITE_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
             $ECR_REGISTRY/api-proctor:latest \
-            tests/${{ github.event.repository.name }}/health.get --testPathIgnorePatterns=/src/ --passWithNoTests --runInBand
+            tests/${{ github.event.repository.name }}/health.get --testPathIgnorePatterns=/src/ --passWithNoTests
 
       - name: Docker Compose logs
         shell: bash

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -270,7 +270,7 @@ jobs:
           docker run --rm --name api-proctor --network host \
             -e READ_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
             -e WRITE_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
-            $ECR_REGISTRY/api-proctor:dev-19dea32 \
+            $ECR_REGISTRY/api-proctor:pr-experiment-remove-common-tests \
             tests/${{ github.event.repository.name }}/health.get --testPathIgnorePatterns=/src/ --passWithNoTests
 
       - name: Docker Compose logs

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -237,11 +237,9 @@ jobs:
             unset work_set[${next}]
             # Add the next node to the dependency set, and add any of its
             # unvisited dependencies to the work set.
-            echo Visiting ${next}...
             deps[${next}]=1
             next_deps=$(yq ".services.${next}.depends_on[]" docker-compose.yml | sort | uniq)
             for next_dep in ${next_deps}; do
-              echo ...depends on ${next_dep}
               if [[ ! ${deps[${next_dep}]} ]]; then
                 work_set[${next_dep}]=1
               fi
@@ -253,7 +251,6 @@ jobs:
       - name: Start postgres and create service databases and roles
         shell: bash
         run: |
-          pwd
           docker-compose up -d postgres
           timeout 1m bash -c 'until docker-compose run postgres pg_isready -d postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres; do sleep 1s; done'
           declare -A dbs

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -163,7 +163,6 @@ jobs:
           repository: nicheinc/development
           token: ${{ secrets.NPM_WRITE_TOKEN }}
           submodules: true
-          ref: x/read-only-bool
 
       - name: Download docker image artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -311,15 +311,16 @@ jobs:
         if: success() || failure()
         shell: bash
         run: |
-          echo "::group::Docker ${{ github.event.repository.name }} logs"
-          echo "--- Kafka logs ---"
-          docker-compose logs kafka || echo "Kafka not running"
-          echo "--- Postgres logs ---"
-          docker-compose logs postgres || echo "Postgres not running"
           for service in ${{ steps.parse-services.outputs.services }}; do
-            echo "--- ${service} logs ---"
+            echo "::group::${service} logs"
             docker-compose logs ${service}
+            echo "::endgroup::"
           done
+          echo "::group::kafka logs"
+          docker-compose logs kafka || echo "kafka not running"
+          echo "::endgroup::"
+          echo "::group::postgres logs"
+          docker-compose logs postgres || echo "postgres not running"
           echo "::endgroup::"
 
   # Post release status to #deployment.

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -271,7 +271,7 @@ jobs:
             -e READ_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
             -e WRITE_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
             $ECR_REGISTRY/api-proctor:pr-x-push-node-env-ci \
-            tests/${{ github.event.repository.name }}/health.get --testPathIgnorePatterns=/src/ --passWithNoTests
+            tests/${{ github.event.repository.name }}/ --testPathIgnorePatterns=/src/ --passWithNoTests
 
       - name: Docker Compose logs
         shell: bash

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -215,11 +215,13 @@ jobs:
           touch vault/website.secrets.env
           touch vault/landingpageadmin.secrets.env
 
-      - name: Launch service with dependencies in docker-compose
+      - name: Launch services with dependencies via docker-compose
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         shell: bash
-        run: docker-compose -f docker-compose.yml -f docker-compose.ci.yaml up -d ${{ steps.parse-services.outputs.services }}
+        run: |
+          docker-compose pull
+          docker-compose -f docker-compose.yml -f docker-compose.ci.yaml up -d ${{ steps.parse-services.outputs.services }}
 
       - name: API Proctor health check test
         env:

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -216,6 +216,25 @@ jobs:
           touch vault/website.secrets.env
           touch vault/landingpageadmin.secrets.env
 
+      - name: Create service databases and roles
+        shell: bash
+        run: |
+          # Parse unique usernames, passwords, and DBs from POSTGRES_CONNECTION strings.
+          declare -A db_info
+          while read -r line; do
+            regex='postgres://(\w*):(\w*)@\$\{POSTGRES_SERVER\}/(\w*)'
+            if [[ $line =~ $regex ]]; then
+              # Map username to the associated password and DB.
+              db_info[${BASH_REMATCH[1]}]=${BASH_REMATCH[@]:2:2}
+            fi
+          done < <(grep POSTGRES_CONNECTION docker-compose.yml)
+          for username in "${!db_info[@]}"; do
+            read -r password db <<<$(echo ${db_info[$username]})
+            # Create database and role.
+            psql -c "CREATE DATABASE IF NOT EXISTS $db"
+            psql -c "CREATE ROLE $username LOGIN PASSWORD $password"
+          done
+
       - name: Launch services with dependencies via docker-compose
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -145,7 +145,7 @@ jobs:
       fail-fast: false
       matrix:
         service: ${{ fromJson(inputs.services) }}
-    if: ${{ !github.event.draft && !github.event.release }}
+    if: ${{ !github.event.pull_request.draft && !github.event.release }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -267,7 +267,7 @@ jobs:
             -e READ_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
             -e WRITE_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
             $ECR_REGISTRY/api-proctor:latest \
-            tests/${{ github.event.repository.name }}/ --testPathIgnorePatterns=/src/ --passWithNoTests
+            tests/${{ github.event.repository.name }}/health.get --testPathIgnorePatterns=/src/ --passWithNoTests --runInBand
 
       - name: Docker Compose logs
         shell: bash

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -258,12 +258,14 @@ jobs:
         shell: bash
         run: docker-compose logs entity
 
-      - name: API Proctor health check test
+      - name: Run API Proctor tests
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         shell: bash
         run: |
           docker run --rm --name api-proctor --network host \
+            -e READ_POSTGRES_CONNECTION=postgres://postgres:prowl3r@localhost:5433 \
+            -e WRITE_POSTGRES_CONNECTION=postgres://postgres:prowl3r@localhost:5433 \
             $ECR_REGISTRY/api-proctor:v1.3.0 \
             tests/${{ github.event.repository.name }}/ --testPathIgnorePatterns=/src/ --passWithNoTests
 

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -234,7 +234,9 @@ jobs:
             docker-compose up -d postgres
             docker-compose logs postgres
             docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres psql -h 0.0.0.0 -U ${POSTGRES_USER} -c \
-              "CREATE DATABASE ${db}; COMMIT; CREATE ROLE ${username} LOGIN PASSWORD '${password}'; COMMIT"
+              "CREATE DATABASE ${db}"
+            docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres psql -h 0.0.0.0 -U ${POSTGRES_USER} -c \
+              "CREATE ROLE ${username} LOGIN PASSWORD '${password}'"
           done
 
       - name: Launch services with dependencies via docker-compose

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -228,11 +228,11 @@ jobs:
               db_info[${BASH_REMATCH[1]}]=${BASH_REMATCH[@]:2:2}
             fi
           done < <(grep POSTGRES_CONNECTION docker-compose.yml)
-          # Start postgres in docker and create databases and roles.
-          docker-compose up -d postgres
           for username in "${!db_info[@]}"; do
             read -r password db <<<$(echo ${db_info[${username}]})
-            echo Creating ${username} role and ${db} DB
+            # Start postgres in docker and create database and role.
+            docker-compose up -d postgres
+            docker-compose logs postgres
             docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres psql -h 0.0.0.0 -U ${POSTGRES_USER} -c \
               "CREATE DATABASE ${db}"
             docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres psql -h 0.0.0.0 -U ${POSTGRES_USER} -c \

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -220,7 +220,7 @@ jobs:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         shell: bash
         run: |
-          docker-compose -f docker-compose.yml -f docker-compose.ci.yaml \
+          docker-compose --pull always -f docker-compose.yml -f docker-compose.ci.yaml \
             up -d ${{ steps.parse-services.outputs.services }}
 
       - name: View entity logs, for debugging

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -149,7 +149,7 @@ jobs:
         uses: docker/build-push-action@v2
         if: ${{ github.event.release }}
         env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REGISTRY: ${{ needs.amazon-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ matrix.service }}
           IMAGE_TAG: ${{ github.ref_name }}
         with:

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -183,10 +183,16 @@ jobs:
       - name: Download docker image artifacts
         uses: actions/download-artifact@v3
 
+      - name: Parse services into a space-separated string
+        id: parse-services
+        shell: bash
+        run: echo "::set-output name=services::`jq 'join(" ")' <<< '${{ inputs.services }}'`"
+
       - name: Load docker images
         shell: bash
         run: |
-          for service in ${SERVICES}; do
+          echo Services: ${{ steps.parse-services.outputs.services }}
+          for service in ${{ steps.parse-services.outputs.services }}; do
             docker load --input ${service}/${service}.tar
           done
 
@@ -196,7 +202,7 @@ jobs:
         shell: bash
         run: |
           echo -e "version: '3.7'\nservices:" >> docker-compose.ci.yaml
-          for service in ${SERVICES}; do
+          for service in ${{ steps.parse-services.outputs.services }}; do
             echo -e "  ${service}:\n    image: ${service}:ci" >> docker-compose.ci.yaml
           done
           echo $ENCODED_CREDENTIALS | base64 -di > vault/aws_credentials
@@ -205,7 +211,7 @@ jobs:
         env:
           REGISTRY: ${{ needs.amazon-ecr.outputs.registry }}
         shell: bash
-        run: docker-compose -f docker-compose.yml -f docker-compose.ci.yaml up -d ${SERVICES}
+        run: docker-compose -f docker-compose.yml -f docker-compose.ci.yaml up -d ${{ steps.parse-services.outputs.services }}
 
       - name: api-proctor health check test
         env:
@@ -227,7 +233,7 @@ jobs:
           docker-compose logs kafka || echo "Kafka not running"
           echo "--- Postgres logs ---"
           docker-compose logs postgres || echo "Postgres not running"
-          for service in ${SERVICES}; do
+          for service in ${{ steps.parse-services.outputs.services }}; do
             echo "--- ${service} logs ---"
             docker-compose logs ${service}
           done

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -231,6 +231,7 @@ jobs:
     needs: build-and-ship-images
     timeout-minutes: ${{ inputs.api-proctor-timeout-minutes }}
     env:
+      PGADMIN_PORT: 5000
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_SERVER: postgres

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -267,7 +267,7 @@ jobs:
             -e READ_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
             -e WRITE_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
             $ECR_REGISTRY/api-proctor:latest \
-            tests/${{ github.event.repository.name }} --testPathIgnorePatterns=/src/ --passWithNoTests
+            tests/${{ github.event.repository.name }}/ --testPathIgnorePatterns=/src/ --passWithNoTests
 
       - name: Docker Compose logs
         shell: bash

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -186,7 +186,7 @@ jobs:
       - name: Parse services into a space-separated string
         id: parse-services
         shell: bash
-        run: echo "::set-output name=services::`jq 'join(" ")' <<< '${{ inputs.services }}'`"
+        run: echo "::set-output name=services::`jq -r 'join(" ")' <<< '${{ inputs.services }}'`"
 
       - name: Load docker images
         shell: bash

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -231,7 +231,6 @@ jobs:
     needs: build-and-ship-images
     timeout-minutes: ${{ inputs.api-proctor-timeout-minutes }}
     env:
-      PGADMIN_PORT: 5000
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_SERVER: postgres

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -216,15 +216,20 @@ jobs:
       - name: Use latest service images from ECR
         run: sed -i 's/${USER:?USER}/${{ steps.login-ecr.outputs.registry }}/' docker-compose.yml
 
+      - name: Set up yq for YAML processing
+        uses: mikefarah/yq@v4.27.3
+
       - name: Create docker-compose override and AWS credentials files
         env:
           ENCODED_CREDENTIALS: ${{ secrets.DEV_AWS_CREDENTIALS }}
         shell: bash
         run: |
-          echo -e "version: '3.7'\nservices:" > docker-compose.override.yaml
+          yq -n '.version = 3.7' > docker-compose.override.yaml
           for service in ${{ steps.parse-services.outputs.services }}; do
-            echo -e "  ${service}:\n    image: ${service}:ci" >> docker-compose.override.yaml
+            yq -i ".services.${service}.image = \"${service}:ci\"" docker-compose.override.yaml
           done
+          echo docker-compose.override.yaml:
+          cat docker-compose.override.yaml
           echo $ENCODED_CREDENTIALS | base64 -di > vault/aws_credentials
 
       # TODO: This is a hack to place empty secret files in the vault directory
@@ -235,9 +240,6 @@ jobs:
         run: |
           touch vault/website.secrets.env
           touch vault/landingpageadmin.secrets.env
-
-      - name: Set up yq for YAML processing
-        uses: mikefarah/yq@v4.27.3
 
       - name: Parse service dependencies
         id: parse-deps

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -365,7 +365,7 @@ jobs:
         run: |
           docker-compose pull --include-deps ${{ steps.get-services.outputs.services }}
           docker-compose up -d ${{ steps.get-services.outputs.services }}
-          sleep 1
+          sleep 1m
 
       - name: Run API Proctor tests
         env:

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -270,7 +270,7 @@ jobs:
           docker run --rm --name api-proctor --network host \
             -e READ_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
             -e WRITE_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
-            -e NODE_ENV=ci
+            -e NODE_ENV=ci \
             $ECR_REGISTRY/api-proctor:latest \
             tests/${{ github.event.repository.name }}/ --testPathIgnorePatterns=/src/ --passWithNoTests
 

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -195,7 +195,7 @@ jobs:
           ENCODED_CREDENTIALS: ${{ secrets.DEV_AWS_CREDENTIALS }}
         shell: bash
         run: |
-          echo "services:" >> docker-compose.ci.yaml
+          echo -e "version: '3.7'\nservices:" >> docker-compose.ci.yaml
           for service in ${SERVICES}; do
             echo -e "  ${service}:\n    image: ${service}:ci" >> docker-compose.ci.yaml
           done

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -232,6 +232,7 @@ jobs:
             read -r password db <<<$(echo ${db_info[${username}]})
             # Start postgres in docker and create database and role.
             docker-compose up -d postgres
+            docker-compose logs postgres
             docker exec -i postgres psql -U ${POSTGRES_USER} -c \
               "CREATE DATABASE ${db}; CREATE ROLE ${username} LOGIN PASSWORD '${password}'"
           done

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -204,6 +204,12 @@ jobs:
       - name: Trim down docker-compose.yml
         run: yq -i 'del(.services.*.build, .services.*.env_file)' docker-compose.yml
 
+      # TODO: Once we update the development repo itself to use latest images
+      # from ECR (https://app.asana.com/0/1199932090708798/1202699911962363/f),
+      # this step will be unnecessary.
+      - name: Use latest service images from ECR
+        run: sed -i 's/${USER:?USER}/${{ needs.amazon-ecr.outputs.registry }}/' docker-compose.yml
+
       - name: Create docker-compose override and AWS credentials files
         env:
           ENCODED_CREDENTIALS: ${{ secrets.DEV_AWS_CREDENTIALS }}

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -237,7 +237,7 @@ jobs:
             # Add the next node to the dependency set, and add any of its
             # unvisited dependencies to the work set.
             deps[${next}]=1
-            next_deps=$(yq ".services.${next}.depends_on[]" docker-compose.yml | sort | uniq)
+            next_deps=$(yq ".services.${next}.depends_on[]" docker-compose.yml)
             for next_dep in ${next_deps}; do
               if [[ ! ${deps[${next_dep}]} ]]; then
                 work_set[${next_dep}]=1

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -236,10 +236,12 @@ jobs:
             unset work_set[${next}]
             # Add the next node to the dependency set, and add any of its
             # unvisited dependencies to the work set.
+            echo Visiting ${next}...
             deps[${next}]=1
             next_deps=$(yq ".services.${next}.depends_on" docker-compose.yml | sort | uniq)
             if [[ ${next_deps} != null ]]; then
               for next_dep in ${next_deps}; do
+                echo ...depends on ${next_dep}
                 if [[ ! ${deps[${next_dep}]} ]]; then
                   work_set[${next_dep}]=1
                 fi

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -14,12 +14,6 @@ on:
         description: The timeout in minutes for running API Proctor tests.
         default: 30
         type: number
-      uses_elasticsearch:
-        description: >
-          Boolean representing if the service 
-          depends upon elasticsearch or not.
-        default: false
-        type: boolean
     secrets:
       DEV_AWS_CREDENTIALS:
         required: true
@@ -364,15 +358,6 @@ jobs:
             fi
           done
 
-      - name: Launch elasticsearch via docker-compose
-        if: ${{ inputs.uses_elasticsearch }}
-        env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        shell: bash
-        run: |
-          docker-compose pull --include-deps elasticsearch
-          docker compose up -d --wait elasticsearch
-
       - name: Launch services with dependencies via docker-compose
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -380,6 +365,7 @@ jobs:
         run: |
           docker-compose pull --include-deps ${{ steps.get-services.outputs.services }}
           docker-compose up -d ${{ steps.get-services.outputs.services }}
+          sleep 1
 
       - name: Run API Proctor tests
         env:

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -33,7 +33,7 @@ jobs:
       matrix: ${{ steps.versions.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set Go versions
         uses: arnested/go-version-action@v1
@@ -51,7 +51,7 @@ jobs:
         go: ${{ fromJSON(needs.go-versions.outputs.matrix) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Go
         uses: actions/setup-go@v3
@@ -76,7 +76,7 @@ jobs:
         service: ${{ fromJson(inputs.services) }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -158,11 +158,12 @@ jobs:
       POSTGRES_PORT: 5432
     steps:
       - name: Checkout development repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: nicheinc/development
           token: ${{ secrets.NPM_WRITE_TOKEN }}
           submodules: true
+          ref: x/read-only-bool
 
       - name: Download docker image artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -308,6 +308,7 @@ jobs:
             tests/${{ github.event.repository.name }}/ --testPathIgnorePatterns=/src/ --passWithNoTests
 
       - name: Docker Compose logs
+        if: success() || failure()
         shell: bash
         run: |
           echo "::group::Docker ${{ github.event.repository.name }} logs"

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -264,8 +264,8 @@ jobs:
         shell: bash
         run: |
           docker run --rm --name api-proctor --network host \
-            -e READ_POSTGRES_CONNECTION=postgres://postgres:prowl3r@localhost:5432 \
-            -e WRITE_POSTGRES_CONNECTION=postgres://postgres:prowl3r@localhost:5432 \
+            -e READ_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
+            -e WRITE_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
             $ECR_REGISTRY/api-proctor:v1.3.0 \
             tests/${{ github.event.repository.name }}/ --testPathIgnorePatterns=/src/ --passWithNoTests
 

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -197,7 +197,10 @@ jobs:
       fail-fast: false
       matrix:
         service: ${{ fromJson(inputs.services) }}
-    if: ${{ !github.event.pull_request.draft && github.event_name != 'release' }}
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'push' &&
+        steps.check-version-change.outputs.appchange == 'false')
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -134,7 +134,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      # Build and upload image artifact for use in api-proctor tests.
+      # Since jobs can't access local files produced by other jobs, we build and
+      # upload a GitHub artifact containing a TAR of the ci-tagged service
+      # image, to be downloaded in the run-api-proctor-tests job.
       - name: Build image for api-proctor tests
         uses: docker/build-push-action@v3
         with:
@@ -144,7 +146,6 @@ jobs:
           cache-to: type=gha,mode=max
           outputs: type=docker,dest=${{ matrix.service }}.tar
           tags: ${{ matrix.service }}:ci
-
       - name: Upload docker image artifact
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -14,6 +14,12 @@ on:
         description: The timeout in minutes for running API Proctor tests.
         default: 30
         type: number
+      uses_elasticsearch:
+        description: >
+          Boolean representing if the service 
+          depends upon elasticsearch or not.
+        default: false
+        type: boolean
     secrets:
       DEV_AWS_CREDENTIALS:
         required: true
@@ -357,6 +363,15 @@ jobs:
               fi
             fi
           done
+
+      - name: Launch elasticsearch via docker-compose
+        if: ${{ inputs.uses_elasticsearch }}
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        shell: bash
+        run: |
+          docker-compose pull --include-deps elasticsearch
+          docker compose up -d --wait elasticsearch
 
       - name: Launch services with dependencies via docker-compose
         env:

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -248,20 +248,6 @@ jobs:
           docker-compose -f docker-compose.yml -f docker-compose.ci.yaml \
             up -d ${{ steps.parse-services.outputs.services }}
 
-      - name: View kafka logs, for debugging
-        shell: bash
-        run: |
-          docker-compose ps | grep kafka
-          docker-compose logs kafka
-
-      - name: View entity logs, for debugging
-        shell: bash
-        run: docker-compose logs entity
-
-      - name: Manually call entity health check
-        shell: bash
-        run: curl -v http://localhost:34000/health
-
       - name: Run API Proctor tests
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -11,6 +11,10 @@ on:
           eponymous microservice itself, any associated Kafka consumers, etc.
         required: true
         type: string
+      run-api-proctor-tests:
+        description: Run the API Proctor tests associated with this repo.
+        default: true
+        type: boolean
       api-proctor-timeout-minutes:
         description: The timeout in minutes for running API Proctor tests.
         default: 30
@@ -138,6 +142,7 @@ jobs:
       # upload a GitHub artifact containing a TAR of the ci-tagged service
       # image, to be downloaded in the run-api-proctor-tests job.
       - name: Build image for api-proctor tests
+        if: inputs.run-api-proctor-tests
         uses: docker/build-push-action@v3
         with:
           context: .
@@ -147,6 +152,7 @@ jobs:
           outputs: type=docker,dest=${{ matrix.service }}.tar
           tags: ${{ matrix.service }}:ci
       - name: Upload docker image artifact
+        if: inputs.run-api-proctor-tests
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.service }}
@@ -220,6 +226,7 @@ jobs:
 
   run-api-proctor-tests:
     name: Run API Proctor tests
+    if: inputs.run-api-proctor-tests
     runs-on: ubuntu-latest
     needs: build-and-ship-images
     timeout-minutes: ${{ inputs.api-proctor-timeout-minutes }}

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -145,16 +145,8 @@ jobs:
       fail-fast: false
       matrix:
         service: ${{ fromJson(inputs.services) }}
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && !github.event.release }}
     steps:
-      - name: Print github.event context value for debugging
-        shell: bash
-        run: |
-          echo Event name: ${{ github.event_name }}
-          echo github.event: ${{ github.event }}
-          echo github.event.pull_request: ${{ github.event.pull_request }}
-          echo github.event.pull_request.draft: ${{ github.event.pull_request.draft }}
-
       - name: Checkout repo
         uses: actions/checkout@v3
 

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -231,11 +231,9 @@ jobs:
           for username in "${!db_info[@]}"; do
             read -r password db <<<$(echo ${db_info[${username}]})
             # Start postgres in docker and create database and role.
-            docker-compose up -d postgres
-            docker-compose logs postgres
-            docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres psql -h 0.0.0.0 -U ${POSTGRES_USER} -c \
+            docker-compose exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres psql -h 0.0.0.0 -U ${POSTGRES_USER} -c \
               "CREATE DATABASE ${db}"
-            docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres psql -h 0.0.0.0 -U ${POSTGRES_USER} -c \
+            docker-compose exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres psql -h 0.0.0.0 -U ${POSTGRES_USER} -c \
               "CREATE ROLE ${username} LOGIN PASSWORD '${password}'"
           done
 

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -228,11 +228,11 @@ jobs:
               db_info[${BASH_REMATCH[1]}]=${BASH_REMATCH[@]:2:2}
             fi
           done < <(grep POSTGRES_CONNECTION docker-compose.yml)
+          # Start postgres in docker and create databases and roles.
+          docker-compose up -d postgres
           for username in "${!db_info[@]}"; do
             read -r password db <<<$(echo ${db_info[${username}]})
-            # Start postgres in docker and create database and role.
-            docker-compose up -d postgres
-            docker-compose logs postgres
+            echo Creating ${username} role and ${db} DB
             docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres psql -h 0.0.0.0 -U ${POSTGRES_USER} -c \
               "CREATE DATABASE ${db}"
             docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres psql -h 0.0.0.0 -U ${POSTGRES_USER} -c \

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -248,6 +248,12 @@ jobs:
           docker-compose -f docker-compose.yml -f docker-compose.ci.yaml \
             up -d ${{ steps.parse-services.outputs.services }}
 
+      - name: View kafka logs, for debugging
+        shell: bash
+        run: |
+          docker-compose ps | grep kafka
+          docker-compose logs kafka
+
       - name: View entity logs, for debugging
         shell: bash
         run: docker-compose logs entity

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -201,9 +201,9 @@ jobs:
           ENCODED_CREDENTIALS: ${{ secrets.DEV_AWS_CREDENTIALS }}
         shell: bash
         run: |
-          echo -e "version: '3.7'\nservices:" >> docker-compose.ci.yaml
+          echo -e "version: '3.7'\nservices:" > docker-compose.override.yaml
           for service in ${{ steps.parse-services.outputs.services }}; do
-            echo -e "  ${service}:\n    image: ${service}:ci" >> docker-compose.ci.yaml
+            echo -e "  ${service}:\n    image: ${service}:ci" >> docker-compose.override.yaml
           done
           echo $ENCODED_CREDENTIALS | base64 -di > vault/aws_credentials
 
@@ -245,8 +245,7 @@ jobs:
         shell: bash
         run: |
           docker-compose pull --include-deps ${{ steps.parse-services.outputs.services }}
-          docker-compose -f docker-compose.yml -f docker-compose.ci.yaml \
-            up -d ${{ steps.parse-services.outputs.services }}
+          docker-compose up -d ${{ steps.parse-services.outputs.services }}
 
       - name: Run API Proctor tests
         env:

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -267,7 +267,7 @@ jobs:
             -e READ_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
             -e WRITE_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
             $ECR_REGISTRY/api-proctor:v1.3.0 \
-            tests/${{ github.event.repository.name }}/ --testPathIgnorePatterns=/src/ --passWithNoTests
+            tests/${{ github.event.repository.name }}/v3.entity.get.test.ts --testPathIgnorePatterns=/src/ --passWithNoTests
 
       - name: Docker Compose logs
         shell: bash

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -232,9 +232,9 @@ jobs:
             read -r password db <<<$(echo ${db_info[${username}]})
             # Start postgres in docker and create database and role.
             docker-compose up -d postgres
-            docker-compose logs postgres
-            docker exec -i postgres psql -h ${POSTGRES_SERVER} -U ${POSTGRES_USER} -c \
+            docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres psql -h ${POSTGRES_SERVER} -U ${POSTGRES_USER} -c \
               "CREATE DATABASE ${db}; CREATE ROLE ${username} LOGIN PASSWORD '${password}'"
+            docker-compose logs postgres
           done
 
       - name: Launch services with dependencies via docker-compose

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -238,11 +238,13 @@ jobs:
             # unvisited dependencies to the work set.
             deps[${next}]=1
             next_deps=$(yq ".services.${next}.depends_on" docker-compose.yml | sort | uniq)
-            for next_dep in ${next_deps}; do
-              if [[ ! ${deps[${next_dep}]} ]]; then
-                work_set[${next_dep}]=1
-              fi
-            done
+            if [[ ${next_deps} != null ]]; then
+              for next_dep in ${next_deps}; do
+                if [[ ! ${deps[${next_dep}]} ]]; then
+                  work_set[${next_dep}]=1
+                fi
+              done
+            fi
           done
           echo Dependencies: ${!deps[@]}
           echo "::set-output name=deps::${!deps[@]}"

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -36,7 +36,7 @@ jobs:
     outputs:
       matrix: ${{ steps.versions.outputs.matrix }}
     steps:
-      - name: Checkout
+      - name: Checkout repo
         uses: actions/checkout@v3
 
       - name: Set Go versions
@@ -45,7 +45,7 @@ jobs:
 
   # Run unit tests and go vet with each supported Go version. Skip on release.
   unit-test-and-vet:
-    name: "Unit test and vet with Go ${{ matrix.go }}"
+    name: Unit test and vet with Go ${{ matrix.go }}
     runs-on: ubuntu-latest
     if: ${{ !github.event.release }}
     needs: go-versions
@@ -54,7 +54,7 @@ jobs:
       matrix:
         go: ${{ fromJSON(needs.go-versions.outputs.matrix) }}
     steps:
-      - name: Checkout code
+      - name: Checkout repo
         uses: actions/checkout@v3
 
       - name: Install Go
@@ -70,16 +70,16 @@ jobs:
         run: |
           go vet ./...
 
-  # Build the docker images on PR or push to dev/master, ship on release.
-  build-and-ship-image:
-    name: "Build ${{ matrix.service }} image"
+  # Build image for api-proctor and, on release, ship final images to ECR.
+  build-and-ship-images:
+    name: Build ${{ matrix.service }} images
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         service: ${{ fromJson(inputs.services) }}
     steps:
-      - name: Checkout Repo
+      - name: Checkout repo
         uses: actions/checkout@v3
 
       - name: Set up QEMU
@@ -89,7 +89,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       # Build and upload image artifact for use in api-proctor tests.
-      - name: Build image for CI
+      - name: Build image for api-proctor tests
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -106,19 +106,7 @@ jobs:
           path: ${{ matrix.service }}.tar
           retention-days: 1
 
-      # TODO: Disabled for development. Reenable before this branch is merged.
-      # On push/PR, ensure service images can be built on target platforms.
-      # - name: Build final images
-      #  uses: docker/build-push-action@v2
-      #  if: ${{ !github.event.release }}
-      #  with:
-      #    context: .
-      #    file: ./cmd/${{ matrix.service }}/Dockerfile
-      #    cache-from: type=gha
-      #    cache-to: type=gha,mode=max
-      #    platforms: linux/amd64,linux/arm64
-
-      # On release, build service images and push to ECR.
+      # On release, build service images for target platforms and push to ECR.
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         if: ${{ github.event.release }}
@@ -150,10 +138,37 @@ jobs:
             ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
             ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:latest
 
+  build-for-target-platforms:
+    name: Verify ${{ matrix.service }} images can be built on target platforms
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        service: ${{ fromJson(inputs.services) }}
+    if: ${{ !github.event.draft && !github.event.release }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build images on target platforms
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./cmd/${{ matrix.service }}/Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+
   run-api-proctor-tests:
     name: Run api-proctor tests
     runs-on: ubuntu-latest
-    needs: build-and-ship-image
+    needs: build-and-ship-images
     timeout-minutes: ${{ inputs.api-proctor-timeout-minutes }}
     env:
       PGADMIN_PORT: 5000
@@ -327,7 +342,7 @@ jobs:
   update-slack:
     name: Update Slack
     runs-on: ubuntu-latest
-    needs: build-and-ship-image
+    needs: build-and-ship-images
     if: ${{ github.event.release }}
     steps:
       - name: Post to a Slack channel

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -264,8 +264,8 @@ jobs:
         shell: bash
         run: |
           docker run --rm --name api-proctor --network host \
-            -e READ_POSTGRES_CONNECTION=postgres://postgres:prowl3r@localhost:5433 \
-            -e WRITE_POSTGRES_CONNECTION=postgres://postgres:prowl3r@localhost:5433 \
+            -e READ_POSTGRES_CONNECTION=postgres://postgres:prowl3r@localhost:5432 \
+            -e WRITE_POSTGRES_CONNECTION=postgres://postgres:prowl3r@localhost:5432 \
             $ECR_REGISTRY/api-proctor:v1.3.0 \
             tests/${{ github.event.repository.name }}/ --testPathIgnorePatterns=/src/ --passWithNoTests
 

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -66,28 +66,10 @@ jobs:
         run: |
           go vet ./...
 
-  amazon-ecr:
-    name: "Login to Amazon ECR"
-    runs-on: ubuntu-latest
-    outputs:
-      registry: ${{ steps.login-ecr.outputs.registry }}
-    steps:
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.ECR_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.ECR_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-
-      - name: Login
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-
   # Build the docker images on PR or push to dev/master, ship on release.
   build-and-ship-image:
     name: "Build ${{ matrix.service }} image"
     runs-on: ubuntu-latest
-    needs: amazon-ecr
     strategy:
       fail-fast: false
       matrix:
@@ -149,7 +131,7 @@ jobs:
         uses: docker/build-push-action@v2
         if: ${{ github.event.release }}
         env:
-          ECR_REGISTRY: ${{ needs.amazon-ecr.outputs.registry }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ matrix.service }}
           IMAGE_TAG: ${{ github.ref_name }}
         with:
@@ -166,7 +148,7 @@ jobs:
   run-api-proctor-tests:
     name: Run api-proctor tests
     runs-on: ubuntu-latest
-    needs: [amazon-ecr, build-and-ship-image]
+    needs: build-and-ship-image
     env:
       PGADMIN_PORT: 5000
       POSTGRES_USER: postgres
@@ -196,11 +178,22 @@ jobs:
             docker load --input ${service}/${service}.tar
           done
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.ECR_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ECR_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
       # TODO: Once we update the development repo itself to use latest images
       # from ECR (https://app.asana.com/0/1199932090708798/1202699911962363/f),
       # this step will be unnecessary.
       - name: Use latest service images from ECR
-        run: sed -i 's/${USER:?USER}/${{ needs.amazon-ecr.outputs.registry }}/' docker-compose.yml
+        run: sed -i 's/${USER:?USER}/${{ steps.login-ecr.outputs.registry }}/' docker-compose.yml
 
       - name: Create docker-compose override and AWS credentials files
         env:
@@ -224,13 +217,13 @@ jobs:
 
       - name: Launch service with dependencies in docker-compose
         env:
-          REGISTRY: ${{ needs.amazon-ecr.outputs.registry }}
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         shell: bash
         run: docker-compose -f docker-compose.yml -f docker-compose.ci.yaml up -d ${{ steps.parse-services.outputs.services }}
 
-      - name: api-proctor health check test
+      - name: API Proctor health check test
         env:
-          ECR_REGISTRY: ${{ needs.amazon-ecr.outputs.registry }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         shell: bash
         run: |
           docker run \

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -197,11 +197,7 @@ jobs:
       fail-fast: false
       matrix:
         service: ${{ fromJson(inputs.services) }}
-    if: |
-      (github.event_name == 'pull_request' &&
-        !github.event.pull_request.draft) ||
-      (github.event_name == 'push' &&
-        steps.check-version-change.outputs.appchange == 'false')
+    if: github.event_name == 'pull_request' && !github.event.pull_request.draft
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -195,15 +195,6 @@ jobs:
             docker load --input ${service}/${service}.tar
           done
 
-      - name: Set up yq for YAML processing
-        uses: mikefarah/yq@v4.27.3
-
-      # We only use docker-compose.yml for its dependency graph, not for build
-      # configuration. Since we don't check out submodules, we need to remove
-      # any references to submodule files.
-      - name: Trim down docker-compose.yml
-        run: yq -i 'del(.services.*.build, .services.*.env_file)' docker-compose.yml
-
       # TODO: Once we update the development repo itself to use latest images
       # from ECR (https://app.asana.com/0/1199932090708798/1202699911962363/f),
       # this step will be unnecessary.

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -262,7 +262,7 @@ jobs:
                   psql -h 0.0.0.0 -U ${POSTGRES_USER} -a -c \
                   "CREATE ROLE ${role} LOGIN PASSWORD '${password}'"
               else
-                echo ${role} role already exists
+                echo ${role} role already created
               fi
             fi
           done

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -281,6 +281,7 @@ jobs:
           for service in ${{ steps.get-services.outputs.services }}; do
             yq -i ".services.${service}.image = \"${service}:ci\"" docker-compose.override.yaml
           done
+          yq eval-all --inplace 'select(fileIndex == 0) * select(fileIndex == 1)' docker-compose.override.yaml ${{ github.workspace }}/docker-compose.ci-override.yml
           echo docker-compose.override.yaml:
           cat docker-compose.override.yaml
           echo $ENCODED_CREDENTIALS | base64 -di > vault/aws_credentials

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -145,7 +145,7 @@ jobs:
       fail-fast: false
       matrix:
         service: ${{ fromJson(inputs.services) }}
-    if: ${{ !github.event.pull_request.draft && !github.event.release }}
+    if: ${{ false }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -231,9 +231,11 @@ jobs:
           for username in "${!db_info[@]}"; do
             read -r password db <<<$(echo ${db_info[${username}]})
             # Start postgres in docker and create database and role.
-            docker-compose exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres psql -h 0.0.0.0 -U ${POSTGRES_USER} -c \
+            docker-compose up -d postgres
+            docker-compose logs postgres
+            docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres psql -h 0.0.0.0 -U ${POSTGRES_USER} -c \
               "CREATE DATABASE ${db}"
-            docker-compose exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres psql -h 0.0.0.0 -U ${POSTGRES_USER} -c \
+            docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres psql -h 0.0.0.0 -U ${POSTGRES_USER} -c \
               "CREATE ROLE ${username} LOGIN PASSWORD '${password}'"
           done
 

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -253,20 +253,23 @@ jobs:
           docker-compose up -d postgres
           timeout 1m bash -c 'until docker-compose run postgres pg_isready -d postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres; do sleep 1s; done'
           declare -A dbs
-          declare -A roles
           conn_regex='postgres://(\w*):(\w*)@\$\{POSTGRES_SERVER\}/(\w*)'
           for dependency in ${{ steps.parse-deps.outputs.deps }}; do
-            # Parse role, password, and DB from POSTGRES_CONNECTION.
+            # Parse DB from POSTGRES_CONNECTION. Parse roles and passwords from sql/roles.sql
             conn=$(yq ".services.${dependency}.environment.POSTGRES_CONNECTION" docker-compose.yml)
             if [[ ${conn} =~ ${conn_regex} ]]; then
-              role=${BASH_REMATCH[1]}
-              password=${BASH_REMATCH[2]}
               db=${BASH_REMATCH[3]}
               if [[ ! ${dbs[${db}]} ]]; then
                 dbs[${db}]=1
                 docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres \
                   psql -h 0.0.0.0 -U ${POSTGRES_USER} -a -c "CREATE DATABASE ${db}"
                 context=$(yq ".services.${dependency}.build.context" docker-compose.yml)
+                roles="${context}/sql/roles.sql"
+                if [[ -f ${roles} ]]; then
+                  docker compose cp ${roles} postgres:roles.sql
+                  docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres \
+                    psql -h 0.0.0.0 -U ${POSTGRES_USER} -d ${db} -a -f roles.sql
+                fi
                 extensions="${context}/sql/extensions.sql"
                 if [[ -f ${extensions} ]]; then
                   docker compose cp ${extensions} postgres:extensions.sql
@@ -275,14 +278,6 @@ jobs:
                 fi
               else
                 echo ${db} database already initialized
-              fi
-              if [[ ! ${roles[${role}]} ]]; then
-                roles[${role}]=1
-                docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres \
-                  psql -h 0.0.0.0 -U ${POSTGRES_USER} -a -c \
-                  "CREATE ROLE ${role} LOGIN PASSWORD '${password}'"
-              else
-                echo ${role} role already created
               fi
             fi
           done

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -258,6 +258,10 @@ jobs:
         shell: bash
         run: docker-compose logs entity
 
+      - name: Manually call entity health check
+        shell: bash
+        run: curl -v http://localhost:34000/health
+
       - name: Run API Proctor tests
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -224,7 +224,7 @@ jobs:
           ENCODED_CREDENTIALS: ${{ secrets.DEV_AWS_CREDENTIALS }}
         shell: bash
         run: |
-          yq -n '.version = 3.7' > docker-compose.override.yaml
+          yq -n ".version = \"3.7\"" > docker-compose.override.yaml
           for service in ${{ steps.parse-services.outputs.services }}; do
             yq -i ".services.${service}.image = \"${service}:ci\"" docker-compose.override.yaml
           done

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -267,7 +267,7 @@ jobs:
             -e READ_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
             -e WRITE_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
             $ECR_REGISTRY/api-proctor:latest \
-            tests/${{ github.event.repository.name }}/health.get --testPathIgnorePatterns=/src/ --passWithNoTests
+            tests/${{ github.event.repository.name }}/does-not-exist --testPathIgnorePatterns=/src/ --passWithNoTests
 
       - name: Docker Compose logs
         shell: bash

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -191,9 +191,7 @@ jobs:
       - name: Load docker images
         shell: bash
         run: |
-          echo Services: ${{ steps.parse-services.outputs.services }}
           for service in ${{ steps.parse-services.outputs.services }}; do
-            echo Loading service: ${service}
             docker load --input ${service}/${service}.tar
           done
 

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -232,9 +232,9 @@ jobs:
             read -r password db <<<$(echo ${db_info[${username}]})
             # Start postgres in docker and create database and role.
             docker-compose up -d postgres
-            docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres psql -h ${POSTGRES_SERVER} -U ${POSTGRES_USER} -c \
-              "CREATE DATABASE ${db}; CREATE ROLE ${username} LOGIN PASSWORD '${password}'"
             docker-compose logs postgres
+            docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres psql -h 0.0.0.0 -U ${POSTGRES_USER} -c \
+              "CREATE DATABASE ${db}; CREATE ROLE ${username} LOGIN PASSWORD '${password}'"
           done
 
       - name: Launch services with dependencies via docker-compose

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -250,6 +250,7 @@ jobs:
       - name: Start postgres and create service databases and roles
         shell: bash
         run: |
+          pwd
           docker-compose up -d postgres
           timeout 1m bash -c 'until docker-compose run postgres pg_isready -d postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres; do sleep 5s; done'
           declare -A dbs

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -270,7 +270,8 @@ jobs:
           docker run --rm --name api-proctor --network host \
             -e READ_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
             -e WRITE_POSTGRES_CONNECTION=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT} \
-            $ECR_REGISTRY/api-proctor:pr-x-push-node-env-ci \
+            -e NODE_ENV=ci
+            $ECR_REGISTRY/api-proctor:latest \
             tests/${{ github.event.repository.name }}/ --testPathIgnorePatterns=/src/ --passWithNoTests
 
       - name: Docker Compose logs

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -129,14 +129,14 @@ jobs:
           exit 1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       # Build and upload image artifact for use in api-proctor tests.
       - name: Build image for api-proctor tests
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: ./cmd/${{ matrix.service }}/Dockerfile
@@ -171,7 +171,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: Build and ship final images
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         if: |
           github.event_name == 'push' &&
           steps.check-version-change.outputs.appchange == 'true'
@@ -203,13 +203,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build images on target platforms
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: ./cmd/${{ matrix.service }}/Dockerfile

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -249,7 +249,7 @@ jobs:
                   psql -h 0.0.0.0 -U ${POSTGRES_USER} -a -c "CREATE DATABASE ${db}"
                 context=$(yq ".services.${dependency}.build.context" docker-compose.yml)
                 extensions="${context}/sql/extensions.sql"
-                if [[ test -f ${extensions} ]]; then
+                if [[ -f ${extensions} ]]; then
                   docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres \
                     psql -h 0.0.0.0 -U ${POSTGRES_USER} -d ${db} -a -f ${extensions}
                 fi

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -145,8 +145,15 @@ jobs:
       fail-fast: false
       matrix:
         service: ${{ fromJson(inputs.services) }}
-    if: ${{ false }}
+    if: ${{ !github.event.pull_request.draft }}
     steps:
+      - name: Print github.event context value for debugging
+        shell: bash
+        run: |
+          echo ${{ github.event }}
+          echo ${{ github.event.pull_request }}
+          echo ${{ github.event.pull_request.draft }}
+
       - name: Checkout repo
         uses: actions/checkout@v3
 


### PR DESCRIPTION
### Documentation

- [Asana task](https://app.asana.com/0/1202563967140527/1202561384547922/f)
- [Back-End Patterns & Practices / Continuous Integration](https://bookstack.niche.team/books/back-end-patterns-practices/page/continuous-integration) - BookStack article explaining how prepare a service to use this workflow
- [BE Service CI Status sheet](https://docs.google.com/spreadsheets/d/18JOH27RaSS3KXUxSqEmTYZzPjYRig-DNTTJ1s4kqzrc/edit#gid=0) - lists the current status and next steps for each (Go) BE repo
- Adapted from https://github.com/nicheinc/entity/pull/221

### Description

This PR extends the `build-test-ship` workflow to run [API Proctor](https://github.com/nicheinc/api-proctor) tests. I've left numerous comments on the workflow itself, but I'll also call out some caveats and future work here. Reviewers, don't hesitate to message me or post in `#eso-delta` if you'd like to talk through anything in here!

#### Submodule Checkout

At the moment, this checks out all the `development` submodules so that all the files specified in the `docker-compose.yml` are present (see [this slack thread](https://nicheinc.slack.com/archives/C026TLM8HSL/p1662047480315389)). This takes some time (around 1.5 minutes). Cochran had thoughts in the thread on how to possibly avoid this in the future by eliminating `docker.env` files. There is an [Asana task](https://app.asana.com/0/1201453510342377/1202915568704245/f) for that work, which also describes a related problem where the workflow does not see the current branch's updates to the `docker.env`.

#### GitHub Artifacts

The workflow uses [artifacts](https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts) to store service images built from the current branch of the current repo (identified via the `services` workflow input) so they can be pulled during the `run-api-proctor-tests` job. We only need these images for the duration of the run, but surprisingly there is no first-party action for deleting artifacts. I've set the retention period for the docker image artifacts to 1 day, which I think will clear them soon enough that we won't run into storage limits. However, if we decide we'd like to clear the artifacts immediately, we could use [this API](https://docs.github.com/en/rest/actions/artifacts#delete-an-artifact) or possibly one of the third-party `delete-artifacts` actions floating around.

#### Branches of Dependencies

Except for services from the current repo, the workflow always uses the `latest` service images from ECR, so it has no way to use images from branches of dependencies (e.g. in PRs that depend on PRs in other repos). This could be a little inconvenient during development because tests might fail in CI until the dependency has been deployed. However, by the time the consuming branch is merged, the dependency should be deployed, so we will still have useful checks by the time the dependent PR is merged. This is also only an issue if behavior invoked by _existing_ `api-proctor` tests depends on the updated behavior from the other branch, which is probably not very common. At least for MVP, I don't think this workflow should support branches of dependencies due to the complexity involved.

#### Service Launch/API Proctor Timing

Some services have dependencies, such as Elasticsearch, that can take a while to fully start. Running the API Proctor tests immediately after launching the services with `docker-compose` can result in test failures because, by default, `docker-compose up -d` doesn't wait for services to actually be ready/healthy before returning. Currently, the workflow works around this by [sleeping for one minute](https://github.com/nicheinc/actions/blob/e5be49c5d565184eed55e1357a8d458b402ad48f/.github/workflows/build-test-ship.yaml#L380) between launching the services and running the API Proctor tests, which is usually overkill. We have a [backlog task](https://app.asana.com/0/1201010009456007/1203332769997382/f) that describes the issue (and what we've tried so far) in more detail.

### Testing Considerations

The pilot service branches for this workflow are https://github.com/nicheinc/entity/pull/241, https://github.com/nicheinc/fact/pull/324, and https://github.com/nicheinc/search/pull/238, but we have open branches in all (Go) service repos. The [BE Service CI Status sheet](https://docs.google.com/spreadsheets/d/18JOH27RaSS3KXUxSqEmTYZzPjYRig-DNTTJ1s4kqzrc/edit#gid=0) shows the current status and next steps for each repo.

We should make sure I haven't introduced any regressions during merges, especially in the deployment steps, which are difficult/impossible to test during workflow development.

### Deployment 

The updated workflow from this PR has already been copied into a new repo, https://github.com/nicheinc/actions-go-ci, as described in [this subtask](https://app.asana.com/0/0/1203340028733045/f). Once all CRs are in, we should make any necessary changes over there and close this PR and delete its branch.

We will roll this out to each service repo one-by-one by pointing each service's `ci.yaml` to `nicheinc/actions-go-ci/.github/workflows/action.yaml@v0.1.0`.

### Versioning

This will be version 0.1.0 of a new repo.
