### PR TITLE
Update workflow to pull roles from sql/roles.sql

### DIFF
--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -253,20 +253,23 @@ jobs:
           docker-compose up -d postgres
           timeout 1m bash -c 'until docker-compose run postgres pg_isready -d postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres; do sleep 1s; done'
           declare -A dbs
-          declare -A roles
           conn_regex='postgres://(\w*):(\w*)@\$\{POSTGRES_SERVER\}/(\w*)'
           for dependency in ${{ steps.parse-deps.outputs.deps }}; do
-            # Parse role, password, and DB from POSTGRES_CONNECTION.
+            # Parse DB from POSTGRES_CONNECTION. Parse roles and passwords from sql/roles.sql
             conn=$(yq ".services.${dependency}.environment.POSTGRES_CONNECTION" docker-compose.yml)
             if [[ ${conn} =~ ${conn_regex} ]]; then
-              role=${BASH_REMATCH[1]}
-              password=${BASH_REMATCH[2]}
               db=${BASH_REMATCH[3]}
               if [[ ! ${dbs[${db}]} ]]; then
                 dbs[${db}]=1
                 docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres \
                   psql -h 0.0.0.0 -U ${POSTGRES_USER} -a -c "CREATE DATABASE ${db}"
                 context=$(yq ".services.${dependency}.build.context" docker-compose.yml)
+                roles="${context}/sql/roles.sql"
+                if [[ -f ${roles} ]]; then
+                  docker compose cp ${roles} postgres:roles.sql
+                  docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres \
+                    psql -h 0.0.0.0 -U ${POSTGRES_USER} -d ${db} -a -f roles.sql
+                fi
                 extensions="${context}/sql/extensions.sql"
                 if [[ -f ${extensions} ]]; then
                   docker compose cp ${extensions} postgres:extensions.sql
@@ -275,14 +278,6 @@ jobs:
                 fi
               else
                 echo ${db} database already initialized
-              fi
-              if [[ ! ${roles[${role}]} ]]; then
-                roles[${role}]=1
-                docker exec -i -e PGPASSWORD=${POSTGRES_PASSWORD} postgres \
-                  psql -h 0.0.0.0 -U ${POSTGRES_USER} -a -c \
-                  "CREATE ROLE ${role} LOGIN PASSWORD '${password}'"
-              else
-                echo ${role} role already created
               fi
             fi
           done


### PR DESCRIPTION
@jonathansharman 

### Documentation
- [Fact PR that explains rationale in using `roles.sql`](https://github.com/nicheinc/fact/pull/326)

### Description
This PR changes how roles are created within the workflow. Before, they were parsed using the `POSTGRES_CONNECTION` strings within `docker-compose.yaml`. In this branch, roles and passwords are parsed from a service/dependency's `roles.sql`.

Here is a an example of this workflow running and passing all api-proctor tests within `fact`: https://github.com/nicheinc/fact/actions/runs/3099179283/jobs/5018027999