### PR TITLE
Add option to specify checkout ref in push-charts

### DIFF
--- a/.github/workflows/push-helm-charts.yaml
+++ b/.github/workflows/push-helm-charts.yaml
@@ -45,6 +45,12 @@ on:
         required: false
         default: false
         type: boolean
+      checkout-ref:
+        description:
+          Specify a branch to checkout
+        required: false
+        default: ''
+        type: string
     secrets:
       ECR_ACCESS_KEY_ID:
         required: true
@@ -71,12 +77,14 @@ jobs:
           !inputs.bypass-dev-protections
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ inputs.checkout-ref }}
       # Checkout as given token to bypass branch protections
       - uses: actions/checkout@v2
         if: |
           inputs.bypass-dev-protections
         with:
           token: ${{ secrets.PUSH_CHARTS_TOKEN }}
+          ref: ${{ inputs.checkout-ref }}
 
       # If the chart version changed we need to reflect it in the chart(s).
       # Also reflects app changes if both change in the same PR.

--- a/.github/workflows/push-helm-charts.yaml
+++ b/.github/workflows/push-helm-charts.yaml
@@ -47,7 +47,8 @@ on:
         type: boolean
       checkout-ref:
         description:
-          Specify a branch to checkout
+          Specify a branch, tag, or SHA to checkout documented
+          at https://github.com/actions/checkout
         required: false
         default: ''
         type: string
@@ -72,14 +73,14 @@ jobs:
       github.event_name == 'release'
     steps:
       # Checkout as github-actions for normal workflow
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         if: |
           !inputs.bypass-dev-protections
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ inputs.checkout-ref }}
       # Checkout as given token to bypass branch protections
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         if: |
           inputs.bypass-dev-protections
         with:


### PR DESCRIPTION
<!-- CC relevant team members -->

### Dependencies

DO NOT MERGE until pando PR is also ready to merge so it can be immediately tested/rolled back if needed

### Description

Allows an optional input so that ref can be specified in the checkout actions. This is needed for the new auto bump versions because if a prior job commits/pushed changes the default checkout option will only use the ref that triggered the original workflow and will not pick up the correct versions. 

The default behavior for the checkout is `ref: ''` so, this should be a no-op to everything already consuming this action as the new input is optional and defaults to `''`

documentation related to existing default behavior: https://github.com/actions/checkout 
test run in infra repo of an action using checkout with ref set as '': [using checkout v3 like documentation](https://github.com/nicheinc/infrastructure/actions/runs/4059791964), [using checkout v2 like the push charts actions](https://github.com/nicheinc/infrastructure/actions/runs/4059836997)

### Testing Considerations

<!-- Any specific testing considerations for this PR: dependencies, sample UUIDs, test data etc.-->

### SQL Migrations

<!-- Uncomment and fill out the following section if this PR contains any alterations to the service's database -->

<!--
    Migration Script: <link to migration script file>
    Description: <a description of the specific schema or data changes made by this migration script>

    Keep this tag - the data enablement team will be notified via email of any changes: @nicheinc/data-enablement 
-->

### Deployment 

<!-- Any deployment considerations for this PR, including dependencies, necessary order of operations, etc. -->

<!-- Does this PR represent a new back-end component that has never been deployed before? Consult the Production Readiness Checklist: https://docs.google.com/document/d/1MUjrz0m-zbTc4wmvxdmbCm6B2ML8fAluU7u9CqLSG9g/edit -->

### Versioning

<!-- Indicate whether this is a Major, Minor, or Patch bump and explain why. -->
