### PR TITLE
Add Linkerd Service Profile generation workflow

### DIFF
--- a/.github/workflows/update_service_profile.yaml
+++ b/.github/workflows/update_service_profile.yaml
@@ -1,4 +1,4 @@
-name: Push Helm Charts
+name: Update Service Profile
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/update_service_profile.yaml
+++ b/.github/workflows/update_service_profile.yaml
@@ -38,6 +38,8 @@ jobs:
       - name: Create Service Profile
         run: |
           /tmp/linkerd/linkerd profile --open-api ./openapi/openapi.yaml ${{ inputs.service }} --ignore-cluster > charts/${{ inputs.service }}/templates/serviceprofile.yaml
+          ls charts/${{ inputs.service }}/templates
+          cat charts/${{ inputs.service }}/templates/serviceprofile.yaml
       - name: Push Helm Chart Updates
         run: |
           git diff

--- a/.github/workflows/update_service_profile.yaml
+++ b/.github/workflows/update_service_profile.yaml
@@ -5,13 +5,6 @@ permissions:
 on:
   workflow_call:
     inputs:
-      checkout-ref:
-        description:
-          Specify a branch, tag, or SHA to checkout documented
-          at https://github.com/actions/checkout
-        required: false
-        default: ''
-        type: string
       service:
         description:
           Service Name

--- a/.github/workflows/update_service_profile.yaml
+++ b/.github/workflows/update_service_profile.yaml
@@ -37,7 +37,7 @@ jobs:
           chmod +x "/tmp/linkerd/linkerd"
       - name: Create Service Profile
         run: |
-          /tmp/linderd/linkerd profile --open-api ./openapi/openapi.yaml ${{ inputs.service }} --ignore-cluster > charts/${{ inputs.service }}/templates/serviceprofile.yaml
+          /tmp/linkerd/linkerd profile --open-api ./openapi/openapi.yaml ${{ inputs.service }} --ignore-cluster > charts/${{ inputs.service }}/templates/serviceprofile.yaml
       - name: Push Helm Chart Updates
         run: |
           git diff

--- a/.github/workflows/update_service_profile.yaml
+++ b/.github/workflows/update_service_profile.yaml
@@ -39,7 +39,7 @@ jobs:
           rm -rf "/tmp/linkerd"
       - name: Create Service Profile
         run: |
-          linkerd profile --open-api ./openapi/openapi.yaml ${{ inputs.service }} --ignore-cluster > charts/${{ inputs.service }/templates/serviceprofile.yaml
+          linkerd profile --open-api ./openapi/openapi.yaml ${{ inputs.service }} --ignore-cluster > charts/${{ inputs.service }}/templates/serviceprofile.yaml
       - name: Push Helm Chart Updates
         run: |
           if ! git diff --quiet; then

--- a/.github/workflows/update_service_profile.yaml
+++ b/.github/workflows/update_service_profile.yaml
@@ -1,0 +1,51 @@
+name: Push Helm Charts
+permissions:
+  contents: write
+  pull-requests: write
+on:
+  workflow_call:
+    inputs:
+      checkout-ref:
+        description:
+          Specify a branch, tag, or SHA to checkout documented
+          at https://github.com/actions/checkout
+        required: false
+        default: ''
+        type: string
+      service:
+        description:
+          Service Name
+        required: true
+        type: string
+    secrets:
+      LINKERD_VERSION:
+        required: true
+      PUSH_CHARTS_TOKEN:
+        required: true
+jobs:
+  update-service-profile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.PUSH_CHARTS_TOKEN }}
+          ref: ${{ inputs.checkout-ref }}
+      - name: Install Linkerd
+        run: |
+          mkdir -p "/tmp/linkerd"
+          curl -Lo "/tmp/linkerd/linkerd" "https://github.com/linkerd/linkerd2/releases/download/stable-${{ secrets.LINKERD_VERSION}}/linkerd2-cli-stable-${{ secrets.LINKERD_VERSION }}-linux-amd64"
+          chmod +x "/tmp/linkerd/linkerd"
+          sudo mv "/tmp/linkerd/linkerd" /usr/local/bin/linkerd
+          rm -rf "/tmp/linkerd"
+      - name: Create Service Profile
+        run: |
+          linkerd profile --open-api ./openapi/openapi.yaml ${{ inputs.service }} --ignore-cluster > charts/${{ inputs.service }/templates/serviceprofile.yaml
+      - name: Push Helm Chart Updates
+        run: |
+          if ! git diff --quiet; then
+            git config --global user.name github-actions
+            git config --global user.email ""
+            git add -A
+            git commit -m "[skip ci] Updating Service Profile from Open Api"
+            git push
+          fi

--- a/.github/workflows/update_service_profile.yaml
+++ b/.github/workflows/update_service_profile.yaml
@@ -35,11 +35,9 @@ jobs:
           mkdir -p "/tmp/linkerd"
           curl -Lo "/tmp/linkerd/linkerd" "https://github.com/linkerd/linkerd2/releases/download/stable-${{ secrets.LINKERD_VERSION}}/linkerd2-cli-stable-${{ secrets.LINKERD_VERSION }}-linux-amd64"
           chmod +x "/tmp/linkerd/linkerd"
-          sudo mv "/tmp/linkerd/linkerd" /usr/local/bin/linkerd
-          rm -rf "/tmp/linkerd"
       - name: Create Service Profile
         run: |
-          linkerd profile --open-api ./openapi/openapi.yaml ${{ inputs.service }} --ignore-cluster > charts/${{ inputs.service }}/templates/serviceprofile.yaml
+          /tmp/linkerd/linkerd profile --open-api ./openapi/openapi.yaml ${{ inputs.service }} --ignore-cluster > charts/${{ inputs.service }}/templates/serviceprofile.yaml
       - name: Push Helm Chart Updates
         run: |
           git diff

--- a/.github/workflows/update_service_profile.yaml
+++ b/.github/workflows/update_service_profile.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.PUSH_CHARTS_TOKEN }}
-          ref: ${{ inputs.checkout-ref }}
+          ref: ${{ github.event.pull_request.head.ref }}
       - name: Install Linkerd
         run: |
           mkdir -p "/tmp/linkerd"
@@ -37,9 +37,7 @@ jobs:
           chmod +x "/tmp/linkerd/linkerd"
       - name: Create Service Profile
         run: |
-          /tmp/linkerd/linkerd profile --open-api ./openapi/openapi.yaml ${{ inputs.service }} --ignore-cluster > charts/${{ inputs.service }}/templates/serviceprofile.yaml
-          ls charts/${{ inputs.service }}/templates
-          cat charts/${{ inputs.service }}/templates/serviceprofile.yaml
+          /tmp/linderd/linkerd profile --open-api ./openapi/openapi.yaml ${{ inputs.service }} --ignore-cluster > charts/${{ inputs.service }}/templates/serviceprofile.yaml
       - name: Push Helm Chart Updates
         run: |
           git diff
@@ -48,5 +46,5 @@ jobs:
             git config --global user.email ""
             git add -A
             git commit -m "[skip ci] Updating Service Profile from Open Api"
-            git push
+            git push origin ${{ github.event.pull_request.head.ref }}
           fi

--- a/.github/workflows/update_service_profile.yaml
+++ b/.github/workflows/update_service_profile.yaml
@@ -42,6 +42,7 @@ jobs:
           linkerd profile --open-api ./openapi/openapi.yaml ${{ inputs.service }} --ignore-cluster > charts/${{ inputs.service }}/templates/serviceprofile.yaml
       - name: Push Helm Chart Updates
         run: |
+          git diff
           if ! git diff --quiet; then
             git config --global user.name github-actions
             git config --global user.email ""


### PR DESCRIPTION

### Description

Adding a Shared workflow that will generate a service profile from the OpenApi schema in openapi.yaml and add that to the helm chart.  Making use of a shared workflow may allow for better updates to this process without needing to change all of our service repos. 

Service Profiles allow Linkerd to better understand requests in the service mesh. This can allow for smarter routing, and increased observability from Linkerd. 

This should be accompanied by https://github.com/nicheinc/test-content/pull/83
