### PR TITLE
Git pull right after checkout in bump-versions

### DIFF
--- a/.github/workflows/bump-versions.yaml
+++ b/.github/workflows/bump-versions.yaml
@@ -111,6 +111,8 @@ jobs:
           inputs.bypass-dev-protections
         with:
           token: ${{ secrets.PUSH_CHARTS_TOKEN }}
+      - name: Get latest changes
+        run: git pull
       - name: Calculate desired version changes
         id: get-new-versions
         run: |


### PR DESCRIPTION
### Documentation

[DELTA-688: Make all actions-go-ci steps that push to dev tolerant of upstream changes](https://nicheinc.atlassian.net/browse/DELTA-688)

### Description

This adds a `git pull` right after checking out the repo in the `bump-versions` job. The idea is to give the job the highest chance of avoiding errors like [this one](https://github.com/nicheinc/lead/actions/runs/10272768789/job/28426149763#step:6:16)...

```
error: failed to push some refs to 'https://github.com/nicheinc/lead'
hint: Updates were rejected because the remote contains work that you do not
hint: have locally. This is usually caused by another repository pushing to
hint: the same ref. If you want to integrate the remote changes, use
hint: 'git pull' before pushing again.
```

...when jobs fail and are retried.

See the Jira issue for more details.

### Testing Considerations

[Successful job run](https://github.com/nicheinc/gha-test-environment/actions/runs/10375487694/job/28725260484#step:4:1) in `gha-test-environment`.