### PR TITLE
Add new steps to labelPR job to remove MnR label if version.env has been manually edited

### DIFF
--- a/.github/workflows/bump-versions.yaml
+++ b/.github/workflows/bump-versions.yaml
@@ -126,9 +126,7 @@ jobs:
         env:
           EVENTNAME: ${{ github.event_name }}
   changeVersions:
-    # !! The Merge and Release extension looks for the name "Update versions"
     name: Update versions
-    # !! The Merge and Release extension looks for the name "Update versions"
     runs-on: ubuntu-latest
     needs: parseVersionChangeRequest
     if: |

--- a/.github/workflows/bump-versions.yaml
+++ b/.github/workflows/bump-versions.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Add label
         # Run only if label does not yet exist and version.env has not been changed
         if: |
-          !steps.changed-version-env.outputs.any_changed
+          steps.changed-version-env.outputs.any_changed == 'false'
           && !contains( github.event.pull_request.labels.*.name, 'merge-and-release-extension-compatible')
         uses: actions-ecosystem/action-add-labels@v1
         with:
@@ -63,7 +63,7 @@ jobs:
       - name: Remove label
         # Run only if label already exists and version.env has been changed
         if: |
-          steps.changed-version-env.outputs.any_changed
+          steps.changed-version-env.outputs.any_changed == 'true'
           && contains( github.event.pull_request.labels.*.name, 'merge-and-release-extension-compatible')
         uses: actions-ecosystem/action-remove-labels@v1
         with:
@@ -72,7 +72,7 @@ jobs:
       - name: Output debug logs
         run: |
           echo "version_env_changed=${{ steps.changed-version-env.outputs.any_changed }}"
-          echo "labels=${{ github.event.pull_request.labels.*.name }}"
+          echo "labels=${{ toJSON(github.event.pull_request.labels.*.name) }}"
           echo "labels_contain_mnr=${{ contains( github.event.pull_request.labels.*.name, 'merge-and-release-extension-compatible') }}"
 
   # Increment the APP and CHART versions based on commit message starting with update-versions 

--- a/.github/workflows/bump-versions.yaml
+++ b/.github/workflows/bump-versions.yaml
@@ -41,8 +41,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-          with:
-            fetch-depth: 0
+        with:
+          fetch-depth: 0
     
       - name: Check if version.env already has changes
         id: changed-version-env

--- a/.github/workflows/bump-versions.yaml
+++ b/.github/workflows/bump-versions.yaml
@@ -30,7 +30,7 @@ on:
 jobs:
   #label PR as being compatible with the `update-versions` command
   labelPR:
-    name: Set "merge-and-release-extension-compatible" label
+    name: Set merge-and-release-extension-compatible label
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'pull_request'

--- a/.github/workflows/bump-versions.yaml
+++ b/.github/workflows/bump-versions.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Add label
         # Run only if label does not yet exist and version.env has not been changed
         if: |
-          ${{ !steps.changed-version-env.outputs.any_changed }}
+          !steps.changed-version-env.outputs.any_changed
           && !contains( github.event.pull_request.labels.*.name, 'merge-and-release-extension-compatible')
         uses: actions-ecosystem/action-add-labels@v1
         with:
@@ -63,11 +63,17 @@ jobs:
       - name: Remove label
         # Run only if label already exists and version.env has been changed
         if: |
-          ${{ steps.changed-version-env.outputs.any_changed }}
+          steps.changed-version-env.outputs.any_changed
           && contains( github.event.pull_request.labels.*.name, 'merge-and-release-extension-compatible')
         uses: actions-ecosystem/action-remove-labels@v1
         with:
           labels: merge-and-release-extension-compatible
+
+      - name: Output debug logs
+        run: |
+          echo "version_env_changed=${{ steps.changed-version-env.outputs.any_changed }}"
+          echo "labels=${{ github.event.pull_request.labels.*.name }}"
+          echo "labels_contain_mnr=${{ contains( github.event.pull_request.labels.*.name, 'merge-and-release-extension-compatible') }}"
 
   # Increment the APP and CHART versions based on commit message starting with update-versions 
   parseVersionChangeRequest:

--- a/.github/workflows/bump-versions.yaml
+++ b/.github/workflows/bump-versions.yaml
@@ -30,12 +30,42 @@ on:
 jobs:
   #label PR as being compatible with the `update-versions` command
   labelPR:
-    name: Label PR for update-versions
+    name: Add or remove "merge-and-release-extension-compatible" label
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened' }}
+    if: |
+      ${{ github.event_name == 'pull_request' }}
+      && (
+        ${{ github.event.action == 'opened' }}
+        || ${{ github.event.action == 'synchronize' }}
+      )
     steps:
-      - name: Add Label
+      - name: Checkout repo
+        uses: actions/checkout@v4
+          with:
+            fetch-depth: 0
+    
+      - name: Check if version.env already has changes
+        id: changed-version-env
+        if: github.event_name != 'release'
+        uses: tj-actions/changed-files@467e54813892b0cf302b0bba54d233c861b97f1a
+        with:
+          files: 'version.env'
+
+      - name: Add label
+        # Run only if label does not yet exist and version.env has not been changed
+        if: |
+          ${{ steps.changed-version-env.outputs.any_changed != 'true' }}
+          && contains( github.event.pull_request.labels.*.name, 'merge-and-release-extension-compatible')
         uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: merge-and-release-extension-compatible
+
+      - name: Remove label
+        # Run only if label already exists and version.env has been changed
+        if: |
+          ${{ steps.changed-version-env.outputs.any_changed == 'true' }}
+          && contains( github.event.pull_request.labels.*.name, 'merge-and-release-extension-compatible')
+        uses: actions-ecosystem/action-remove-labels@v1
         with:
           labels: merge-and-release-extension-compatible
 

--- a/.github/workflows/bump-versions.yaml
+++ b/.github/workflows/bump-versions.yaml
@@ -33,10 +33,10 @@ jobs:
     name: Set "merge-and-release-extension-compatible" label
     runs-on: ubuntu-latest
     if: |
-      ${{ github.event_name == 'pull_request' }}
+      github.event_name == 'pull_request'
       && (
-        ${{ github.event.action == 'opened' }}
-        || ${{ github.event.action == 'synchronize' }}
+        github.event.action == 'opened'
+        || github.event.action == 'synchronize'
       )
     steps:
       - name: Checkout repo

--- a/.github/workflows/bump-versions.yaml
+++ b/.github/workflows/bump-versions.yaml
@@ -30,7 +30,7 @@ on:
 jobs:
   #label PR as being compatible with the `update-versions` command
   labelPR:
-    name: Add or remove "merge-and-release-extension-compatible" label
+    name: Set "merge-and-release-extension-compatible" label
     runs-on: ubuntu-latest
     if: |
       ${{ github.event_name == 'pull_request' }}
@@ -54,8 +54,8 @@ jobs:
       - name: Add label
         # Run only if label does not yet exist and version.env has not been changed
         if: |
-          ${{ steps.changed-version-env.outputs.any_changed != 'true' }}
-          && contains( github.event.pull_request.labels.*.name, 'merge-and-release-extension-compatible')
+          ${{ !steps.changed-version-env.outputs.any_changed }}
+          && !contains( github.event.pull_request.labels.*.name, 'merge-and-release-extension-compatible')
         uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: merge-and-release-extension-compatible
@@ -63,7 +63,7 @@ jobs:
       - name: Remove label
         # Run only if label already exists and version.env has been changed
         if: |
-          ${{ steps.changed-version-env.outputs.any_changed == 'true' }}
+          ${{ steps.changed-version-env.outputs.any_changed }}
           && contains( github.event.pull_request.labels.*.name, 'merge-and-release-extension-compatible')
         uses: actions-ecosystem/action-remove-labels@v1
         with:


### PR DESCRIPTION
### Dependencies
N/A.

### Documentation
- [Jira ticket](https://nicheinc.atlassian.net/browse/DELTA-1218?atlOrigin=eyJpIjoiZWEyOTM1NzcwM2Q0NDBiYjllY2JjNGI3MDdiMDFlZjgiLCJwIjoiaiJ9)

### Description
Awhile back ago, I was working on a major version upgrade to the `list` service. I probably thought to myself early on, "I know this is going to be a major version upgrade, so let me just update `version.env` now" (the `validate-semver` job probably yelled at me). Then, a week passed, maybe a weekend too, and it was time to deploy my PR. Forgetting that I had already updated the versioning myself, I used the merge-and-release extension to do another major version bump. In the case of minor or patch versions, this is no big deal, but for a major version it definitely created an extra headache. I'm sure that I'm not the only person who has done this before, I might've just been the first one to do this with a major version where it's noticeable.

This PR prevents this behavior by changing the `labelPR` job to remove the `merge-and-release-compatible` label if:
1. The label has already been attached to the PR.
2. `version.env` has been manually updated.

In order to adequately catch `version.env` updates, the `labelPR` would now run on not just PR `opened` events, but also anytime a commit was pushed. Thus, if you updated `version.env` in a commit after already opening the PR, the label would be removed. If you then made another commit reverting your `version.env` changes, the label would be re-added.

### Testing Considerations
Here are the following test cases I investigated:
| label already exists? | version.env already changed? | expected result   | workflow run link |
|-----------------------|------------------------------|-------------------|-------------------|
| false                 | false                        | label added       |https://github.com/nicheinc/gha-test-environment/actions/runs/12777619519/job/35660486355|
| false                 | true                         | nothing           | https://github.com/nicheinc/gha-test-environment/actions/runs/12792470788/job/35663025133 |
| true                  | false                        | label not removed |https://github.com/nicheinc/gha-test-environment/actions/runs/12792359936/job/35662644096|
| true                  | true                         | label removed     |https://github.com/nicheinc/gha-test-environment/actions/runs/12792402327/job/35662788153|

I also did a deployment of the test PR linked in the table above, everything went as normal.

Note that all my tests were in a BE repo. I don't know why behavior would be different in a FE repo, but keep that limitation in mind.

### Deployment
Merge to `main`.

### Versioning
This workflow has no versioning.