### PR TITLE
Fix issue where merge and release label would never be added to PR

### DIFF
--- a/.github/workflows/bump-versions.yaml
+++ b/.github/workflows/bump-versions.yaml
@@ -37,6 +37,7 @@ jobs:
       && (
         github.event.action == 'opened'
         || github.event.action == 'synchronize'
+        || github.event.action == 'ready_for_review'
       )
     steps:
       - name: Checkout repo


### PR DESCRIPTION
### Dependencies
N/A.

### Documentation
N/A.

### Description
In #28, I changed how we set the `merge-and-release-compatible` label. However, I made one small oversight. In the flow where a user opens a draft PR, pushes all their commits to the draft PR, and only then marks the PR as non-draft / ready for review without any additional commits, when it comes time for deployment, the MnR label wouldn't be applied yet. I saw this out in the wild a few times. This PR fixes that problem by also triggering the labeling job on `ready_for_review` events.

### Testing Considerations
Tested through https://github.com/nicheinc/actions-go-ci/tree/test/actions%2329 which is called by https://github.com/nicheinc/fact/pull/432.
- [x] Draft PR has no merge-and-release label
- [x] Switching to Ready for Review adds label

### Deployment
1. Merge to `main`.
2. Delete https://github.com/nicheinc/actions-go-ci/tree/test/actions%2329.
3. Close https://github.com/nicheinc/fact/pull/432.

### Versioning
Not versioned.