### PR TITLE
Updating AWS cred action to avoid depreciated function

### DIFF
--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -147,7 +147,7 @@ jobs:
 
       # On release, build service images and push to ECR.
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         if: |
           github.event_name == 'push' &&
           steps.check-version-change.outputs.appchange == 'true'

--- a/.github/workflows/build-test-ship.yaml
+++ b/.github/workflows/build-test-ship.yaml
@@ -147,7 +147,7 @@ jobs:
 
       # On release, build service images and push to ECR.
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         if: |
           github.event_name == 'push' &&
           steps.check-version-change.outputs.appchange == 'true'

--- a/.github/workflows/push-helm-charts.yaml
+++ b/.github/workflows/push-helm-charts.yaml
@@ -144,7 +144,7 @@ jobs:
 
       # AWS Setup
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         if: |
           (github.event_name == 'push' &&
            inputs.chartchange == 'true') ||

--- a/.github/workflows/push-helm-charts.yaml
+++ b/.github/workflows/push-helm-charts.yaml
@@ -144,7 +144,7 @@ jobs:
 
       # AWS Setup
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         if: |
           (github.event_name == 'push' &&
            inputs.chartchange == 'true') ||


### PR DESCRIPTION
### Documentation

https://nicheinc.atlassian.net/browse/DELTA-2581

### Description

v1 of AWS cred action is throwing a warning about The `set-output` command is deprecated and will be disabled soon.
Updating to newer version.

### Testing Considerations

Not sure how best to test this without actually deploying something.

