### PR TITLE
Link from Helm chart release body to associated PR, if available

### DIFF
--- a/.github/workflows/push-helm-charts.yaml
+++ b/.github/workflows/push-helm-charts.yaml
@@ -196,6 +196,8 @@ jobs:
           tag: "helm-chart-${{ inputs.chartversion }}"
           prerelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
+          # NOTE: The deploy-stats service parses PR links from chart release
+          # bodies. Do not modify the "[PR] ${0}]" format!
           body: |
             appversion ${{ inputs.appversion }}
 

--- a/.github/workflows/push-helm-charts.yaml
+++ b/.github/workflows/push-helm-charts.yaml
@@ -137,7 +137,7 @@ jobs:
       - name: Mark as Prerelease
         id: mark-prerelease
         if: |
-          github.event_name == 'push' && 
+          github.event_name == 'push' &&
           inputs.chartchange == 'true'
         run: |
           sed -i '/^version/ s/$/-beta/' charts/*/Chart.yaml
@@ -178,6 +178,13 @@ jobs:
             echo "Successfully pushed chart $CHART_TAR_GZ to '$REGISTRY_URL'"
           done
 
+      - name: Get PR Metadata
+        uses: 8BitJonny/gh-get-current-pr@4056877062a1f3b624d5d4c2bedefa9cf51435c9 # v4.0.0
+        id: pr
+        if: |
+          github.event_name == 'push' &&
+          inputs.chartchange == 'true'
+
       # Cut a prerelease for the helm chart if it was a push
       - name: Create Prerelease for Helm Charts
         id: create-helm-prerelease
@@ -192,8 +199,8 @@ jobs:
           body: |
             appversion ${{ inputs.appversion }}
 
-            ${{ github.event.pull_request.number
-              && format('[PR #{0}]({1}/{2}/pull/{0})', github.event.pull_request.number, github.server_url, github.repository)
+            ${{ steps.pr.outputs.pr_found == 'true'
+              && format('[PR #{0}]({1})', steps.pr.outputs.number, steps.pr.outputs.pr_url)
               || 'This release is not associated with any pull request.'
             }}
 

--- a/.github/workflows/push-helm-charts.yaml
+++ b/.github/workflows/push-helm-charts.yaml
@@ -189,7 +189,13 @@ jobs:
           tag: "helm-chart-${{ inputs.chartversion }}"
           prerelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
-          body: appversion ${{ inputs.appversion }}
+          body: |
+            appversion ${{ inputs.appversion }}
+
+            ${{ github.event.pull_request.number
+              && format('[PR #{0}]({1}/{2}/pull/{0})', github.event.pull_request.number, github.server_url, github.repository)
+              || 'This release is not associated with any pull request.'
+            }}
 
       # Notify in Slack
       - name: Post Helm Chart Prerelease to Slack

--- a/.github/workflows/push-helm-charts.yaml
+++ b/.github/workflows/push-helm-charts.yaml
@@ -180,7 +180,7 @@ jobs:
 
       - name: Get PR Metadata
         uses: 8BitJonny/gh-get-current-pr@4056877062a1f3b624d5d4c2bedefa9cf51435c9 # v4.0.0
-        id: pr
+        id: get-pr
         if: |
           github.event_name == 'push' &&
           inputs.chartchange == 'true'
@@ -201,8 +201,8 @@ jobs:
           body: |
             appversion ${{ inputs.appversion }}
 
-            ${{ steps.pr.outputs.pr_found == 'true'
-              && format('[PR #{0}]({1})', steps.pr.outputs.number, steps.pr.outputs.pr_url)
+            ${{ steps.get-pr.outputs.pr_found == 'true'
+              && format('[PR #{0}]({1})', steps.get-pr.outputs.number, steps.get-pr.outputs.pr_url)
               || 'This release is not associated with any pull request.'
             }}
 


### PR DESCRIPTION
### Dependencies

Required for an upcoming `deploy-stats` PR.

### Documentation

- [`DELTA-2615`: deploy-stats - attach PR data to release](https://nicheinc.atlassian.net/browse/DELTA-2615)
- [Slack thread](https://nicheinc.slack.com/archives/C026TLM8HSL/p1761596662488869) discussing the limitations of the current Helm chart release description

### Description

This adds a PR link to the body of the `create-helm-prerelease` step of the `push-charts` job, similar to the link that various CI/CD workflows currently add to the _app version_ releases.

I think this is a handy change regardless, but the motivation for this change is to enable the `deploy-stats` service to use the release associated with a Helm chart version to find the associated PR. Without this info in the Helm chart release specifically, we will not be able to link chart-version-bump-only releases to PRs.

### Testing Considerations

Tested via two `gha-test-environment` releases:

- [`helm-chart-0.2.79`](https://github.com/nicheinc/gha-test-environment/releases/tag/helm-chart-0.2.79) was produced by merging https://github.com/nicheinc/gha-test-environment/pull/176 and correctly links to that PR.
- [`helm-chart-0.2.80`](https://github.com/nicheinc/gha-test-environment/releases/tag/helm-chart-0.2.80) was produced by pushing a chart version bump directly to `dev`, and the release is correctly marked as not associated with any PR.

### Deployment

Merge to `main`.

### Versioning

The `actions` repo, regrettably, is currently unversioned since it contains several different reusable workflows that shouldn't be versioned together. Fortunately, this is a backward-compatible change, so all consumers of `push-helm-charts.yamls@main` should be able to consume this without any problems.