### PR TITLE
Add optional apps input to push-helm-charts, to be written to the Helm chart release

### DIFF
--- a/.github/workflows/push-helm-charts.yaml
+++ b/.github/workflows/push-helm-charts.yaml
@@ -93,6 +93,23 @@ jobs:
       github.event_name == 'push' || 
       github.event_name == 'release'
     steps:
+      - name: Validate required inputs for push events
+        if: github.event_name == 'push'
+        run: |
+          appversion="${{ inputs.appversion }}"
+          echo "appversion=$appversion"
+
+          chartchange="${{ inputs.chartchange }}"
+          echo "chartchange=$chartchange"
+
+          chartversion="${{ inputs.chartversion }}"
+          echo "chartversion=$chartversion"
+
+          if [[ -z "$appversion" || -z "$chartchange" || -z "$chartversion" ]]; then
+            echo "::error::appversion, chartchange, and chartversion are required for push events"
+            exit 1
+          fi
+
       # Checkout as github-actions for normal workflow
       - uses: actions/checkout@v3
         if: |

--- a/.github/workflows/push-helm-charts.yaml
+++ b/.github/workflows/push-helm-charts.yaml
@@ -26,16 +26,6 @@ on:
           The current version of the app
         required: false # Required for push events
         type: string
-      cd-workflow:
-        description: >
-          The name of the CD workflow in the calling repository. If present,
-          this information will be written to the Helm chart release
-          description, marking the release as CD-eligible. If this input is
-          provided, the apps input must also be provided, indicating the set of
-          apps whose deployment to stage will trigger final testing and
-          deployment to production.
-        required: false
-        type: string
       chartchange:
         description: >
           'true' if CHARTVERSION in the version.env file changed, 'false' otherwise
@@ -246,10 +236,6 @@ jobs:
 
             ${{ inputs.apps
               && format('Apps: {0}', join(fromJson(inputs.apps), ', '))
-            }}
-
-            ${{ inputs.cd-workflow
-              && format('To be deployed automatically via `{0}`', inputs.cd-workflow)
             }}
 
       # Notify in Slack

--- a/.github/workflows/push-helm-charts.yaml
+++ b/.github/workflows/push-helm-charts.yaml
@@ -10,28 +10,28 @@ on:
           'true' if APPVERSION in the version.env file changed, 'false' otherwise
         required: true
         type: string
+      apps:
+        description: >
+          A JSON array containing the names of all apps the repo ships to stage.
+          If present, this information will be written to the Helm chart release
+          description.
+
+          Example: '["service", "service-updater"]'
+        required: false
+        type: string
       appversion:
         description: >
           The current version of the app
         required: true
-        type: string
-      cd-apps:
-        description: >
-          A JSON array containing the names of all apps to be deployed to stage
-          and production via CD. If present, this information will be written to
-          the Helm chart release description, marking the release as
-          CD-eligible. If this input is provided, cd-workflow must also be
-          provided.
-
-          Example: '["service", "service-updater"]'
-        required: false
         type: string
       cd-workflow:
         description: >
           The name of the CD workflow in the calling repository. If present,
           this information will be written to the Helm chart release
           description, marking the release as CD-eligible. If this input is
-          provided, cd-apps must also be provided.
+          provided, the apps input must also be provided, indicating the set of
+          apps whose deployment to stage will trigger final testing and
+          deployment to production.
         required: false
         type: string
       chartchange:
@@ -215,9 +215,9 @@ jobs:
           tag: "helm-chart-${{ inputs.chartversion }}"
           prerelease: true
           token: ${{ secrets.GITHUB_TOKEN }}
-          # NOTE: The deploy-stats service parses PR links from chart release
-          # bodies. Do not modify the "[PR] ${0}]" format!
           body: |
+            <!-- The following metadata will be parsed by automation - do not modify! -->
+
             appversion ${{ inputs.appversion }}
 
             ${{ steps.get-pr.outputs.pr_found == 'true'
@@ -225,8 +225,8 @@ jobs:
               || 'This release is not associated with any pull request.'
             }}
 
-            ${{ inputs.cd-apps
-              && format('Apps: {0}', join(fromJson(inputs.cd-apps), ', '))
+            ${{ inputs.apps
+              && format('Apps: {0}', join(fromJson(inputs.apps), ', '))
             }}
 
             ${{ inputs.cd-workflow

--- a/.github/workflows/push-helm-charts.yaml
+++ b/.github/workflows/push-helm-charts.yaml
@@ -15,6 +15,25 @@ on:
           The current version of the app
         required: true
         type: string
+      cd-apps:
+        description: >
+          A JSON array containing the names of all apps to be deployed to stage
+          and production via CD. If present, this information will be written to
+          the Helm chart release description, marking the release as
+          CD-eligible. If this input is provided, cd-workflow must also be
+          provided.
+
+          Example: '["service", "service-updater"]'
+        required: false
+        type: string
+      cd-workflow:
+        description: >
+          The name of the CD workflow in the calling repository. If present,
+          this information will be written to the Helm chart release
+          description, marking the release as CD-eligible. If this input is
+          provided, cd-apps must also be provided.
+        required: false
+        type: string
       chartchange:
         description: >
           'true' if CHARTVERSION in the version.env file changed, 'false' otherwise
@@ -204,6 +223,14 @@ jobs:
             ${{ steps.get-pr.outputs.pr_found == 'true'
               && format('[PR #{0}]({1})', steps.get-pr.outputs.number, steps.get-pr.outputs.pr_url)
               || 'This release is not associated with any pull request.'
+            }}
+
+            ${{ inputs.cd-apps
+              && format('Apps: {0}', join(fromJson(inputs.cd-apps), ', '))
+            }}
+
+            ${{ inputs.cd-workflow
+              && format('To be deployed automatically via `{0}`', inputs.cd-workflow)
             }}
 
       # Notify in Slack

--- a/.github/workflows/push-helm-charts.yaml
+++ b/.github/workflows/push-helm-charts.yaml
@@ -24,7 +24,7 @@ on:
       appversion:
         description: >
           The current version of the app
-        required: true
+        required: false # Required for push events
         type: string
       cd-workflow:
         description: >
@@ -39,12 +39,12 @@ on:
       chartchange:
         description: >
           'true' if CHARTVERSION in the version.env file changed, 'false' otherwise
-        required: true
+        required: false # Required for push events
         type: string
       chartversion:
         description: >
           The current version of the Helm chart(s)
-        required: true
+        required: false # Required for push events
         type: string
       protect-dev:
         description: >

--- a/.github/workflows/push-helm-charts.yaml
+++ b/.github/workflows/push-helm-charts.yaml
@@ -7,8 +7,10 @@ on:
     inputs:
       appchange:
         description: >
+          Deprecated: This input is unused.
+
           'true' if APPVERSION in the version.env file changed, 'false' otherwise
-        required: true
+        required: false
         type: string
       apps:
         description: >


### PR DESCRIPTION
### Dependencies

Required for https://github.com/nicheinc/actions-go-ci/pull/103

### Documentation

[`DELTA-3113`: Update push-helm-charts to accept CD workflow and app list inputs, write to chart release](https://nicheinc.atlassian.net/browse/DELTA-3113)

### Description

This PR adds two new optional inputs: `cd-workflow` and `apps`. If passed, the data from these inputs will be written to the Helm chart release during `push` events. This metadata is primarily intended to facilitate BE CD by allowing `actions-go-ci` to pass some data to the `deploy-stats` service via release bodies, but other callers of `push-helm-charts` may also wish to utilize these inputs in the future. The `apps` input in particular could help enrich our `deploy-stats` data, regardless of whether the PR is using CD.

**EDIT:** This PR no longer adds a `cd-workflow` input. `deploy-stats` doesn't need the workflow name (just the repository name), and `deploy-stats` itself can check for CD eligibility by looking for the `deploy-automatically` label.

### Testing Considerations

Tested via https://github.com/nicheinc/actions-go-ci/pull/103. That PR doesn't test the behavior when the `apps` input isn't provided, but at worst I think we'll get an empty `Apps:` line in the release body.

Edit: [This Website release](https://github.com/nicheinc/website/releases/tag/helm-chart-7.3.711) confirmed after I merged this PR that when `apps` is not passed, nothing new is written to the Helm chart release.
