### PR TITLE
Add new job(s) to handle version bumping labels

### DIFF
--- a/.github/workflows/bump-versions.yaml
+++ b/.github/workflows/bump-versions.yaml
@@ -31,7 +31,7 @@ jobs:
   # Parse PR labels to determine version bump type
   parseVersionLabels:
     name: Parse version bump labels
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: github.event_name == 'push'
     outputs:
       labelsFound: ${{ steps.parse-labels.outputs.labelsFound }}
@@ -110,7 +110,7 @@ jobs:
   # Increment the APP and CHART versions based on commit message starting with update-versions
   parseVersionChangeRequest:
     name: Parse version changes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: github.event_name == 'push'
     outputs:
       requestPattern: ${{ steps.validate-commit.outputs.requestPattern }}
@@ -162,7 +162,7 @@ jobs:
   # Pick label-based outputs if available, otherwise fall back to commit message parsing
   resolveVersionRequest:
     name: Resolve version request
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: [parseVersionLabels, parseVersionChangeRequest] # implicit enforces event_name == 'push'
     outputs:
       requestPattern: ${{ steps.resolve.outputs.requestPattern }}
@@ -193,7 +193,7 @@ jobs:
 
   changeVersions:
     name: Update versions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: resolveVersionRequest
     if: |
       (github.event_name == 'push' &&

--- a/.github/workflows/bump-versions.yaml
+++ b/.github/workflows/bump-versions.yaml
@@ -174,7 +174,6 @@ jobs:
     name: Resolve version request
     runs-on: ubuntu-latest
     needs: [parseVersionLabels, parseVersionChangeRequest]
-    if: always() && !failure() && !cancelled()
     outputs:
       requestPattern: ${{ steps.resolve.outputs.requestPattern }}
       validRequest: ${{ steps.resolve.outputs.validRequest }}

--- a/.github/workflows/bump-versions.yaml
+++ b/.github/workflows/bump-versions.yaml
@@ -163,7 +163,7 @@ jobs:
   resolveVersionRequest:
     name: Resolve version request
     runs-on: ubuntu-slim
-    needs: [parseVersionLabels, parseVersionChangeRequest] # implicit enforces event_name == 'push'
+    needs: [parseVersionLabels, parseVersionChangeRequest] # implicitly enforces event_name == 'push'
     outputs:
       requestPattern: ${{ steps.resolve.outputs.requestPattern }}
       validRequest: ${{ steps.resolve.outputs.validRequest }}

--- a/.github/workflows/bump-versions.yaml
+++ b/.github/workflows/bump-versions.yaml
@@ -42,23 +42,12 @@ jobs:
         uses: 8BitJonny/gh-get-current-pr@4056877062a1f3b624d5d4c2bedefa9cf51435c9 # v4.0.0
         id: get-pr
 
-      - name: Check if version.env already has changes
-        id: changed-version-env
-        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
-        with:
-          files: 'version.env'
-
       - name: Parse version labels from PR
         id: parse-labels
         env:
           PR_FOUND: ${{ steps.get-pr.outputs.pr_found }}
           PR_JSON: ${{ steps.get-pr.outputs.pr }}
         run: |
-          if [ "${{ steps.changed-version-env.outputs.any_changed }}" = "true" ]; then
-            echo "::error::version.env was manually updated in the PR — skipping automated bump"
-            exit 1
-          fi
-
           if [ "$PR_FOUND" != "true" ]; then
             echo "No PR found for this push"
             echo "labelsFound=false" >> $GITHUB_OUTPUT
@@ -122,6 +111,7 @@ jobs:
   parseVersionChangeRequest:
     name: Parse version changes
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
     outputs:
       requestPattern: ${{ steps.validate-commit.outputs.requestPattern }}
       validRequest: ${{ steps.validate-commit.outputs.validRequest }}
@@ -173,15 +163,25 @@ jobs:
   resolveVersionRequest:
     name: Resolve version request
     runs-on: ubuntu-latest
-    needs: [parseVersionLabels, parseVersionChangeRequest]
+    needs: [parseVersionLabels, parseVersionChangeRequest] # implicit enforces event_name == 'push'
     outputs:
       requestPattern: ${{ steps.resolve.outputs.requestPattern }}
       validRequest: ${{ steps.resolve.outputs.validRequest }}
     steps:
+      - name: Check if version.env already has changes
+        id: changed-version-env
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
+        with:
+          files: 'version.env'
+
       - name: Resolve version source
         id: resolve
         run: |
-          if [ "${{ needs.parseVersionLabels.outputs.labelsFound }}" = "true" ]; then
+          if [ "${{ steps.changed-version-env.outputs.any_changed }}" = "true" ]; then
+            echo "::error::version.env was manually updated in the PR — skipping automated bump"
+            echo "requestPattern=" >> $GITHUB_OUTPUT
+            echo "validRequest=false" >> $GITHUB_OUTPUT
+          elif [ "${{ needs.parseVersionLabels.outputs.labelsFound }}" = "true" ]; then
             echo "Using version labels"
             echo "requestPattern=${{ needs.parseVersionLabels.outputs.requestPattern }}" >> $GITHUB_OUTPUT
             echo "validRequest=${{ needs.parseVersionLabels.outputs.validRequest }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/bump-versions.yaml
+++ b/.github/workflows/bump-versions.yaml
@@ -42,12 +42,23 @@ jobs:
         uses: 8BitJonny/gh-get-current-pr@4056877062a1f3b624d5d4c2bedefa9cf51435c9 # v4.0.0
         id: get-pr
 
+      - name: Check if version.env already has changes
+        id: changed-version-env
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
+        with:
+          files: 'version.env'
+
       - name: Parse version labels from PR
         id: parse-labels
         env:
-          PR_FOUND: ${{ steps.get-pr.outputs.pr_found }}                                                                                                                                                                                                                                                    
-          PR_JSON: ${{ steps.get-pr.outputs.pr }}             
+          PR_FOUND: ${{ steps.get-pr.outputs.pr_found }}
+          PR_JSON: ${{ steps.get-pr.outputs.pr }}
         run: |
+          if [ "${{ steps.changed-version-env.outputs.any_changed }}" = "true" ]; then
+            echo "::error::version.env was manually updated in the PR — skipping automated bump"
+            exit 1
+          fi
+
           if [ "$PR_FOUND" != "true" ]; then
             echo "No PR found for this push"
             echo "labelsFound=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/bump-versions.yaml
+++ b/.github/workflows/bump-versions.yaml
@@ -168,6 +168,11 @@ jobs:
       requestPattern: ${{ steps.resolve.outputs.requestPattern }}
       validRequest: ${{ steps.resolve.outputs.validRequest }}
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Check if version.env already has changes
         id: changed-version-env
         uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5

--- a/.github/workflows/bump-versions.yaml
+++ b/.github/workflows/bump-versions.yaml
@@ -22,61 +22,92 @@ on:
     outputs:
       versions-changed-by-ci:
         description: "If the commit message was valid and the versions will change; 'true' or 'false'"
-        value: ${{ jobs.parseVersionChangeRequest.outputs.validRequest }}
+        value: ${{ jobs.resolveVersionRequest.outputs.validRequest }}
     secrets:
       PUSH_CHARTS_TOKEN:
         required: false
 
 jobs:
-  #label PR as being compatible with the `update-versions` command
-  labelPR:
-    name: Set merge-and-release-extension-compatible label
+  # Parse PR labels to determine version bump type
+  parseVersionLabels:
+    name: Parse version bump labels
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'pull_request'
-      && (
-        github.event.action == 'opened'
-        || github.event.action == 'synchronize'
-        || github.event.action == 'ready_for_review'
-      )
+    if: github.event_name == 'push'
+    outputs:
+      labelsFound: ${{ steps.parse-labels.outputs.labelsFound }}
+      requestPattern: ${{ steps.parse-labels.outputs.requestPattern }}
+      validRequest: ${{ steps.parse-labels.outputs.validRequest }}
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-    
-      - name: Check if version.env already has changes
-        id: changed-version-env
-        if: github.event_name != 'release'
-        uses: tj-actions/changed-files@467e54813892b0cf302b0bba54d233c861b97f1a
-        with:
-          files: 'version.env'
+      - name: Get PR for this push
+        uses: 8BitJonny/gh-get-current-pr@4056877062a1f3b624d5d4c2bedefa9cf51435c9 # v4.0.0
+        id: get-pr
 
-      - name: Add label
-        # Run only if label does not yet exist and version.env has not been changed
-        if: |
-          steps.changed-version-env.outputs.any_changed == 'false'
-          && !contains( github.event.pull_request.labels.*.name, 'merge-and-release-extension-compatible')
-        uses: actions-ecosystem/action-add-labels@v1
-        with:
-          labels: merge-and-release-extension-compatible
-
-      - name: Remove label
-        # Run only if label already exists and version.env has been changed
-        if: |
-          steps.changed-version-env.outputs.any_changed == 'true'
-          && contains( github.event.pull_request.labels.*.name, 'merge-and-release-extension-compatible')
-        uses: actions-ecosystem/action-remove-labels@v1
-        with:
-          labels: merge-and-release-extension-compatible
-
-      - name: Output debug logs
+      - name: Parse version labels from PR
+        id: parse-labels
+        env:
+          PR_FOUND: ${{ steps.get-pr.outputs.pr_found }}                                                                                                                                                                                                                                                    
+          PR_JSON: ${{ steps.get-pr.outputs.pr }}             
         run: |
-          echo "version_env_changed=${{ steps.changed-version-env.outputs.any_changed }}"
-          echo "labels=${{ toJSON(github.event.pull_request.labels.*.name) }}"
-          echo "labels_contain_mnr=${{ contains( github.event.pull_request.labels.*.name, 'merge-and-release-extension-compatible') }}"
+          if [ "$PR_FOUND" != "true" ]; then
+            echo "No PR found for this push"
+            echo "labelsFound=false" >> $GITHUB_OUTPUT
+            echo "requestPattern=" >> $GITHUB_OUTPUT
+            echo "validRequest=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
 
-  # Increment the APP and CHART versions based on commit message starting with update-versions 
+          # Extract version labels from PR
+          VERSION_LABELS=$(echo "$PR_JSON" | jq -r '.labels[].name' | grep '^version:' || true)
+          LABEL_COUNT=$(echo "$VERSION_LABELS" | grep -c '^version:' || true)
+
+          if [ "$LABEL_COUNT" -eq 0 ]; then
+            echo "No version labels found"
+            echo "labelsFound=false" >> $GITHUB_OUTPUT
+            echo "requestPattern=" >> $GITHUB_OUTPUT
+            echo "validRequest=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          if [ "$LABEL_COUNT" -gt 1 ]; then
+            echo "::error::Multiple version labels found: $VERSION_LABELS. Apply exactly one version label."
+            exit 1
+          fi
+
+          LABEL=$(echo "$VERSION_LABELS" | head -1)
+          echo "Found version label: $LABEL"
+
+          case "$LABEL" in
+            "version:no-change")
+              requestPattern=""
+              validRequest=false
+              ;;
+            "version:app-patch")
+              requestPattern="app:patch chart:patch"
+              validRequest=true
+              ;;
+            "version:app-minor")
+              requestPattern="app:minor chart:patch"
+              validRequest=true
+              ;;
+            "version:app-major")
+              requestPattern="app:major chart:patch"
+              validRequest=true
+              ;;
+            "version:chart-only")
+              requestPattern="chart:patch"
+              validRequest=true
+              ;;
+            *)
+              echo "::error::Unknown version label: $LABEL"
+              exit 1
+              ;;
+          esac
+
+          echo "labelsFound=true" >> $GITHUB_OUTPUT
+          echo "requestPattern=$requestPattern" >> $GITHUB_OUTPUT
+          echo "validRequest=$validRequest" >> $GITHUB_OUTPUT
+
+  # Increment the APP and CHART versions based on commit message starting with update-versions
   parseVersionChangeRequest:
     name: Parse version changes
     runs-on: ubuntu-latest
@@ -126,13 +157,37 @@ jobs:
           echo "validRequest=${validRequest}" >> $GITHUB_OUTPUT
         env:
           EVENTNAME: ${{ github.event_name }}
+
+  # Pick label-based outputs if available, otherwise fall back to commit message parsing
+  resolveVersionRequest:
+    name: Resolve version request
+    runs-on: ubuntu-latest
+    needs: [parseVersionLabels, parseVersionChangeRequest]
+    if: always() && !failure() && !cancelled()
+    outputs:
+      requestPattern: ${{ steps.resolve.outputs.requestPattern }}
+      validRequest: ${{ steps.resolve.outputs.validRequest }}
+    steps:
+      - name: Resolve version source
+        id: resolve
+        run: |
+          if [ "${{ needs.parseVersionLabels.outputs.labelsFound }}" = "true" ]; then
+            echo "Using version labels"
+            echo "requestPattern=${{ needs.parseVersionLabels.outputs.requestPattern }}" >> $GITHUB_OUTPUT
+            echo "validRequest=${{ needs.parseVersionLabels.outputs.validRequest }}" >> $GITHUB_OUTPUT
+          else
+            echo "Falling back to commit message parsing"
+            echo "requestPattern=${{ needs.parseVersionChangeRequest.outputs.requestPattern }}" >> $GITHUB_OUTPUT
+            echo "validRequest=${{ needs.parseVersionChangeRequest.outputs.validRequest }}" >> $GITHUB_OUTPUT
+          fi
+
   changeVersions:
     name: Update versions
     runs-on: ubuntu-latest
-    needs: parseVersionChangeRequest
+    needs: resolveVersionRequest
     if: |
       (github.event_name == 'push' &&
-        needs.parseVersionChangeRequest.outputs.validRequest == 'true')
+        needs.resolveVersionRequest.outputs.validRequest == 'true')
     steps:
       # Checkout as github-actions for normal workflow
       - uses: actions/checkout@v3
@@ -150,6 +205,8 @@ jobs:
         run: git pull
       - name: Calculate desired version changes
         id: get-new-versions
+        env:
+          REQUEST_PATTERN: ${{needs.resolveVersionRequest.outputs.requestPattern}}
         run: |
           . version.env
           # Check both chart and app for version changes and bump accordingly 
@@ -175,8 +232,8 @@ jobs:
             if [[ $version =~ $rNumRegex ]]; then
               echo "Version fits pattern r123 where 123 are any digits"
               # If the versioning is r123 format, ignore patch/major/minor as it can only be a +1
-              echo "outputs: ${outputs}"
-              if [[ "${outputs}" == *"${i}:"* ]]; then
+              echo "REQUEST_PATTERN: ${REQUEST_PATTERN}"
+              if [[ "${REQUEST_PATTERN}" == *"${i}:"* ]]; then
                 newVers="${version:1}"
                 ((newVers+=1))
                 printf -v version 'r%d' "$((newVers))"
@@ -185,12 +242,12 @@ jobs:
             elif [[ $version =~ $semRegex ]]; then
               echo "Version uses semantic versioning"
               IFS=. read -r major minor patch <<<"$version"
-              if [[ "${outputs}" == *"${i}:patch"* ]]; then
+              if [[ "${REQUEST_PATTERN}" == *"${i}:patch"* ]]; then
                 ((patch+=1))
-              elif [[ "${outputs}" == *"${i}:minor"* ]]; then
+              elif [[ "${REQUEST_PATTERN}" == *"${i}:minor"* ]]; then
                 ((minor+=1))
                 patch="0"
-              elif [[ "${outputs}" == *"${i}:major"* ]]; then
+              elif [[ "${REQUEST_PATTERN}" == *"${i}:major"* ]]; then
                 ((major+=1))
                 patch="0"
                 minor="0"
@@ -209,8 +266,6 @@ jobs:
               echo "newAppversion=${version}" >> $GITHUB_OUTPUT
             fi
           done
-        env:
-          outputs: ${{needs.parseVersionChangeRequest.outputs.requestPattern}}
       - name: Update Versions in version.env
         id: update-versions
         run: |


### PR DESCRIPTION
### Dependencies
N/A.

### Documentation
- [Jira issue](https://nicheinc.atlassian.net/browse/DELTA-3309?atlOrigin=eyJpIjoiZDYxMDc2NzI2MjM3NGYyZGFiN2IwOGRjODdiN2RlOTAiLCJwIjoiaiJ9)

### Description
We want our deployable repos to have 5 new labels:
* `version:no-change`
* `version:app-patch`
* `version:app-minor`
* `version:app-major`
* `version:chart-only`

These labels will eventually replace the magic strings we currently use (which are themselves a bandaid over the broken merge and release extension).

This PR adds two new jobs:
1. `parseVersionLabels`: parses the merged PR for version update labels
2. `resolveVersionRequest`: makes version labels take precedence over commit messages.

We can remove `resolveVersionRequest` once we remove the magic commit strings.

### Testing Considerations
Tested through https://github.com/nicheinc/actions-go-ci/pull/114.

Test cases:
  | Completed? | Label Applied | Outcome |                                                                                                                                                                                                                                                                             
  |:---:|---|---|
  | https://github.com/nicheinc/gha-test-environment/actions/runs/23562110190/job/68604437783 | No version label | Falls back to commit message parsing |                                                                                                                                                                                                                                                        
  | https://github.com/nicheinc/gha-test-environment/actions/runs/23562284623/job/68605056635 | No version label and no commit messaging | No version.env change |                                                                                                                                                                                                                                                        
  | https://github.com/nicheinc/gha-test-environment/actions/runs/23562415945/job/68605538520 | `version:no-change` | No version bump |                                                                                                                                                                                                                                                                          
  | https://github.com/nicheinc/gha-test-environment/commit/48260ec2c334ec5462ff926543e7a91d73071798 | `version:app-patch` | App patch bump + chart patch bump |                                                                                                                                                                                                                                                        
  | https://github.com/nicheinc/gha-test-environment/actions/runs/23562524034/job/68605919795#step:5:69 | `version:app-minor` | App minor bump + chart patch bump |                                                                                                                                                                                                                                                        
  | skipped | `version:app-major` | App major bump + chart patch bump |                                                                                                                                                                                                                                                        
  | http://github.com/nicheinc/gha-test-environment/actions/runs/23562606878/job/68606230354#step:5:66 | `version:chart-only` | Chart patch bump only, no app change |                                                                                                                                                                                                                                                    
  | https://github.com/nicheinc/gha-test-environment/actions/runs/23562652463/job/68606312336 | Multiple version labels | Workflow errors with message to apply exactly one |          
  | https://github.com/nicheinc/gha-test-environment/actions/runs/23562766614/job/68606755319 | version.env already manually updated | Workflow errors with message |          

### Deployment

Just merge to `main`. There's follow-up work to get the labels set in every repo.

### Versioning

No versioning here.