### PR TITLE
Retry PR lookup in bump-versions to dodge commit→PR index lag

### DIFF
--- a/.github/workflows/bump-versions.yaml
+++ b/.github/workflows/bump-versions.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Wait for commit→PR index to catch up
         if: steps.get-pr-1.outputs.pr_found != 'true'
         shell: bash
-        run: sleep 15
+        run: sleep 30
 
       - name: Get PR for this event (attempt 2)
         if: steps.get-pr-1.outputs.pr_found != 'true'

--- a/.github/workflows/bump-versions.yaml
+++ b/.github/workflows/bump-versions.yaml
@@ -91,8 +91,12 @@ jobs:
           else
             found=false; pr=""
           fi
-          echo "pr_found=$found" >> "$GITHUB_OUTPUT"
-          { echo 'pr<<EOF'; echo "$pr"; echo EOF; } >> "$GITHUB_OUTPUT"
+          echo "pr_found=$found" >> $GITHUB_OUTPUT
+
+          random_delimiter="$(openssl rand -base64 12)"
+          echo "pr<<${random_delimiter}" >> $GITHUB_OUTPUT
+          echo "${pr}" >> $GITHUB_OUTPUT
+          echo "${random_delimiter}" >> $GITHUB_OUTPUT
 
       - name: Parse version labels from PR
         id: parse-labels

--- a/.github/workflows/bump-versions.yaml
+++ b/.github/workflows/bump-versions.yaml
@@ -59,9 +59,40 @@ jobs:
       appChange: ${{ steps.parse-labels.outputs.appChange }}
       chartChange: ${{ steps.parse-labels.outputs.chartChange }}
     steps:
-      - name: Get PR for this event
+      # GitHub's commit→PR index is eventually consistent; a push-triggered
+      # workflow can race the index and return pr_found=false for a commit
+      # whose PR has clearly been merged. Retry once after a short wait.
+      - name: Get PR for this event (attempt 1)
         uses: *actions-get-current-pr
+        id: get-pr-1
+
+      - name: Wait for commit→PR index to catch up
+        if: steps.get-pr-1.outputs.pr_found != 'true'
+        shell: bash
+        run: sleep 15
+
+      - name: Get PR for this event (attempt 2)
+        if: steps.get-pr-1.outputs.pr_found != 'true'
+        uses: *actions-get-current-pr
+        id: get-pr-2
+
+      - name: Resolve PR result
         id: get-pr
+        env:
+          PR1_FOUND: ${{ steps.get-pr-1.outputs.pr_found }}
+          PR1: ${{ steps.get-pr-1.outputs.pr }}
+          PR2_FOUND: ${{ steps.get-pr-2.outputs.pr_found }}
+          PR2: ${{ steps.get-pr-2.outputs.pr }}
+        run: |
+          if [ "$PR1_FOUND" = "true" ]; then
+            found=true; pr="$PR1"
+          elif [ "$PR2_FOUND" = "true" ]; then
+            found=true; pr="$PR2"
+          else
+            found=false; pr=""
+          fi
+          echo "pr_found=$found" >> "$GITHUB_OUTPUT"
+          { echo 'pr<<EOF'; echo "$pr"; echo EOF; } >> "$GITHUB_OUTPUT"
 
       - name: Parse version labels from PR
         id: parse-labels


### PR DESCRIPTION
## Summary
- In `bump-versions.yaml`, the `parseVersionLabels` job has twice recently reported `pr_found=false` for a push whose merge commit clearly corresponds to a merged PR; manual re-runs minutes later succeed. Context: https://nicheinc.slack.com/archives/C026TLM8HSL/p1776711319544239
- Root cause: `8BitJonny/gh-get-current-pr` calls GitHub's REST `listPullRequestsAssociatedWithCommit`, whose commit→PR index is eventually consistent. Push-triggered runs that start seconds after a merge can race the index. In the most recent failure, the workflow started 4s after merge and saw `pr_found=false`; a re-run ~6 minutes later succeeded against the same SHA.
- Fix: invoke the action twice with a 15s sleep between attempts, then resolve the first successful result into `steps.get-pr.outputs.{pr_found,pr}` so downstream steps are unchanged.

## Test plan
- [x] Call this version from `gha-test-environment` and merge a PR with a version update label. Ensure that versions are still correctly updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)