### PR TITLE
DELTA-3834: Update actions for Node 24 runner support

### DIFF
--- a/.github/workflows/bump-versions.yaml
+++ b/.github/workflows/bump-versions.yaml
@@ -42,8 +42,8 @@ on:
 
 env:
   # First-party GitHub actions
-  ACTIONS_CHECKOUT: &actions-checkout actions/checkout@v6
-  # Third-party actions
+  ACTIONS_CHECKOUT: &actions-checkout actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+  # Niche composite actions
   ACTIONS_GET_CURRENT_PR: &actions-get-current-pr 8BitJonny/gh-get-current-pr@4056877062a1f3b624d5d4c2bedefa9cf51435c9 # v4.0.0
 
 jobs:

--- a/.github/workflows/bump-versions.yaml
+++ b/.github/workflows/bump-versions.yaml
@@ -44,7 +44,7 @@ env:
   # First-party GitHub actions
   ACTIONS_CHECKOUT: &actions-checkout actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
   # Niche composite actions
-  ACTIONS_GET_CURRENT_PR: &actions-get-current-pr nicheinc/get-pr-metadata@DELTA-3834-add-pr-labels-output
+  ACTIONS_GET_CURRENT_PR: &actions-get-current-pr nicheinc/get-pr-metadata@v1
 
 jobs:
   # Parse PR labels to determine version bump type

--- a/.github/workflows/bump-versions.yaml
+++ b/.github/workflows/bump-versions.yaml
@@ -44,7 +44,7 @@ env:
   # First-party GitHub actions
   ACTIONS_CHECKOUT: &actions-checkout actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
   # Niche composite actions
-  ACTIONS_GET_CURRENT_PR: &actions-get-current-pr 8BitJonny/gh-get-current-pr@4056877062a1f3b624d5d4c2bedefa9cf51435c9 # v4.0.0
+  ACTIONS_GET_CURRENT_PR: &actions-get-current-pr nicheinc/get-pr-metadata@DELTA-3834-add-pr-labels-output
 
 jobs:
   # Parse PR labels to determine version bump type
@@ -65,6 +65,8 @@ jobs:
       - name: Get PR for this event (attempt 1)
         uses: *actions-get-current-pr
         id: get-pr-1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Wait for commit→PR index to catch up
         if: steps.get-pr-1.outputs.pr_found != 'true'
@@ -75,34 +77,36 @@ jobs:
         if: steps.get-pr-1.outputs.pr_found != 'true'
         uses: *actions-get-current-pr
         id: get-pr-2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Resolve PR result
         id: get-pr
         env:
           PR1_FOUND: ${{ steps.get-pr-1.outputs.pr_found }}
-          PR1: ${{ steps.get-pr-1.outputs.pr }}
+          PR1_LABELS: ${{ steps.get-pr-1.outputs.pr_labels }}
           PR2_FOUND: ${{ steps.get-pr-2.outputs.pr_found }}
-          PR2: ${{ steps.get-pr-2.outputs.pr }}
+          PR2_LABELS: ${{ steps.get-pr-2.outputs.pr_labels }}
         run: |
           if [ "$PR1_FOUND" = "true" ]; then
-            found=true; pr="$PR1"
+            found=true; labels="$PR1_LABELS"
           elif [ "$PR2_FOUND" = "true" ]; then
-            found=true; pr="$PR2"
+            found=true; labels="$PR2_LABELS"
           else
-            found=false; pr=""
+            found=false; labels=""
           fi
           echo "pr_found=$found" >> $GITHUB_OUTPUT
 
           random_delimiter="$(openssl rand -base64 12)"
-          echo "pr<<${random_delimiter}" >> $GITHUB_OUTPUT
-          echo "${pr}" >> $GITHUB_OUTPUT
+          echo "pr_labels<<${random_delimiter}" >> $GITHUB_OUTPUT
+          echo "${labels}" >> $GITHUB_OUTPUT
           echo "${random_delimiter}" >> $GITHUB_OUTPUT
 
       - name: Parse version labels from PR
         id: parse-labels
         env:
           PR_FOUND: ${{ steps.get-pr.outputs.pr_found }}
-          PR_JSON: ${{ steps.get-pr.outputs.pr }}
+          PR_LABELS: ${{ steps.get-pr.outputs.pr_labels }}
         run: |
           if [ "$PR_FOUND" != "true" ]; then
             echo "No PR found for this event"
@@ -111,7 +115,7 @@ jobs:
           fi
 
           # Extract version labels from PR
-          VERSION_LABELS=$(echo "$PR_JSON" | jq -r '.labels[].name' | grep '^version:' || true)
+          VERSION_LABELS=$(echo "$PR_LABELS" | grep '^version:' || true)
           LABEL_COUNT=$(echo "$VERSION_LABELS" | grep -c '^version:' || true)
 
           if [ "$LABEL_COUNT" -eq 0 ]; then

--- a/.github/workflows/prod_cdn_sync.yaml
+++ b/.github/workflows/prod_cdn_sync.yaml
@@ -26,7 +26,7 @@ jobs:
     name: Syncing Prod CDN
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: jakejarvis/s3-sync-action@7ed8b112447abb09f1da74f3466e4194fc7a6311
         with:
           args: --exclude "\*.webp" --size-only

--- a/.github/workflows/push-helm-charts.yaml
+++ b/.github/workflows/push-helm-charts.yaml
@@ -207,7 +207,7 @@ jobs:
           done
 
       - name: Get PR Metadata
-        uses: nicheinc/get-pr-metadata@DELTA-3834-add-pr-labels-output
+        uses: nicheinc/get-pr-metadata@v1
         id: get-pr
         if: |
           github.event_name == 'push' &&

--- a/.github/workflows/push-helm-charts.yaml
+++ b/.github/workflows/push-helm-charts.yaml
@@ -172,7 +172,7 @@ jobs:
 
       # AWS Setup
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         if: |
           (github.event_name == 'push' &&
            inputs.chartchange == 'true') ||

--- a/.github/workflows/push-helm-charts.yaml
+++ b/.github/workflows/push-helm-charts.yaml
@@ -218,7 +218,7 @@ jobs:
       # Cut a prerelease for the helm chart if it was a push
       - name: Create Prerelease for Helm Charts
         id: create-helm-prerelease
-        uses: ncipollo/release-action@3d2de22e3d0beab188d8129c27f103d8e91bf13a
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         if: |
           github.event_name == 'push' &&
           inputs.chartchange == 'true'

--- a/.github/workflows/push-helm-charts.yaml
+++ b/.github/workflows/push-helm-charts.yaml
@@ -207,11 +207,13 @@ jobs:
           done
 
       - name: Get PR Metadata
-        uses: 8BitJonny/gh-get-current-pr@4056877062a1f3b624d5d4c2bedefa9cf51435c9 # v4.0.0
+        uses: nicheinc/get-pr-metadata@DELTA-3834-add-pr-labels-output
         id: get-pr
         if: |
           github.event_name == 'push' &&
           inputs.chartchange == 'true'
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Cut a prerelease for the helm chart if it was a push
       - name: Create Prerelease for Helm Charts
@@ -230,7 +232,7 @@ jobs:
             appversion ${{ inputs.appversion }}
 
             ${{ steps.get-pr.outputs.pr_found == 'true'
-              && format('[PR #{0}]({1})', steps.get-pr.outputs.number, steps.get-pr.outputs.pr_url)
+              && format('[PR #{0}]({1})', steps.get-pr.outputs.pr_number, steps.get-pr.outputs.pr_url)
               || 'This release is not associated with any pull request.'
             }}
 

--- a/.github/workflows/push-helm-charts.yaml
+++ b/.github/workflows/push-helm-charts.yaml
@@ -101,14 +101,14 @@ jobs:
           fi
 
       # Checkout as github-actions for normal workflow
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         if: |
           !inputs.bypass-dev-protections
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ inputs.checkout-ref }}
       # Checkout as given token to bypass branch protections
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         if: |
           inputs.bypass-dev-protections
         with:

--- a/.github/workflows/push-helm-charts.yaml
+++ b/.github/workflows/push-helm-charts.yaml
@@ -246,25 +246,23 @@ jobs:
           github.event_name == 'push' && 
           inputs.chartchange == 'true' &&
           !inputs.no-slack
-        uses: slackapi/slack-github-action@v1.17.0
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
-          channel-id: 'C2C5JV162'
-          slack-message: |
-            GitHub has built `${{ github.event.repository.name }}:helm-chart-${{ inputs.chartversion }}` 
-            for <${{ steps.create-helm-prerelease.outputs.html_url }}|release>. :shipitparrot:
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: "C2C5JV162"
+            text: "GitHub has built `${{ github.event.repository.name }}:helm-chart-${{ inputs.chartversion }}` for <${{ steps.create-helm-prerelease.outputs.html_url }}|release>. :shipitparrot:"
 
       - name: Post Helm Chart Release to Slack
         if: |
           github.event_name == 'release' &&
           startsWith(github.ref_name, 'helm-chart') &&
           !inputs.no-slack
-        uses: slackapi/slack-github-action@v1.17.0
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
-          channel-id: 'C2C5JV162'
-          slack-message: |
-            GitHub has promoted `${{ github.event.repository.name }}:${{ github.ref_name }}` 
-            to production. :shipitparrot:
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: "C2C5JV162"
+            text: "GitHub has promoted `${{ github.event.repository.name }}:${{ github.ref_name }}` to production. :shipitparrot:"

--- a/.github/workflows/push-helm-charts.yaml
+++ b/.github/workflows/push-helm-charts.yaml
@@ -152,7 +152,7 @@ jobs:
           github.event_name == 'push' &&
           inputs.chartchange == 'true' &&
           inputs.protect-dev
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           base: dev
           branch: chart-version-update


### PR DESCRIPTION
<!-- Niche Back-End PR Template -->

<!-- CC relevant team members -->

<!-- Add the appropriate ai-usage:* label (see https://nicheinc.atlassian.net/wiki/spaces/tech/pages/1024131076 for details) -->

### Documentation
Jira: [DELTA-3834](https://nicheinc.atlassian.net/browse/DELTA-3834)
[Deprecation of Node 20 on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

### Description
This branch updates the actions versions that support Node v24 as [v20 is now deprecated for GitHub Action runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

### Testing Considerations
A temporary `gha-test-environment` [PR](https://github.com/nicheinc/gha-test-environment/pull/239) was created for validating these updates via [actions-go-ci](https://github.com/nicheinc/actions-go-ci/compare/main...DELTA-3834-temp) (targeting the `nicheinc/actions` feature branch)
- GHA Summary for trigger: push on `dev` branch: https://github.com/nicheinc/gha-test-environment/actions/runs/28044732338
- `actions-go-ci` version targeting [feature branch](https://github.com/nicheinc/gha-test-environment/actions/runs/28044732338/job/83019748970#step:1:32)
- `bump-versions.yaml`:
  -  [Parse version update labels](https://github.com/nicheinc/gha-test-environment/actions/runs/28044732338/job/83019780321#step:1:26)
  - [update version.env](https://github.com/nicheinc/gha-test-environment/actions/runs/28044732338/job/83019869643#step:1:26)
- `push-charts.yaml`:
  - [Push Helm Charts](https://github.com/nicheinc/gha-test-environment/actions/runs/28044732338/job/83020323337#step:1:36)
- [Release slack notification](https://nicheinc.slack.com/archives/C3PRNS8DR/p1782236206401829) in `#qa-test` channel
- [New Release created](https://github.com/nicheinc/gha-test-environment/releases/tag/v0.6.3)
- [New helm-chart pre-release created](https://github.com/nicheinc/gha-test-environment/releases/tag/helm-chart-0.2.98)

> [!NOTE]
> [prod_cdn_sync.yaml](https://github.com/nicheinc/actions/blob/DELTA-3834-gha-node-24-support/.github/workflows/prod_cdn_sync.yaml) is only leveraged in [Website](https://github.com/nicheinc/Website/blob/dev/.github/workflows/prod_cdn_sync.yaml#L12) and is not easily testable in [gha-test-environment](https://github.com/nicheinc/gha-test-environment) but its a low risk given the scope of the change (i.e. version bump to `actions/checkout`)


### Deployment
N/A - Merge PR into `main` branch

### Versioning
No version update required as consuming GHA workflows target the `main` branch


[DELTA-3834]: https://nicheinc.atlassian.net/browse/DELTA-3834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ