### PR TITLE
DELTA-4087: Point at actions-get-pr-metadata

### DIFF
--- a/.github/workflows/bump-versions.yaml
+++ b/.github/workflows/bump-versions.yaml
@@ -44,7 +44,7 @@ env:
   # First-party GitHub actions
   ACTIONS_CHECKOUT: &actions-checkout actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
   # Niche composite actions
-  ACTIONS_GET_CURRENT_PR: &actions-get-current-pr nicheinc/get-pr-metadata@v1
+  ACTIONS_GET_CURRENT_PR: &actions-get-current-pr nicheinc/actions-get-pr-metadata@v1
 
 jobs:
   # Parse PR labels to determine version bump type

--- a/.github/workflows/push-helm-charts.yaml
+++ b/.github/workflows/push-helm-charts.yaml
@@ -207,7 +207,7 @@ jobs:
           done
 
       - name: Get PR Metadata
-        uses: nicheinc/get-pr-metadata@v1
+        uses: nicheinc/actions-get-pr-metadata@v1
         id: get-pr
         if: |
           github.event_name == 'push' &&


### PR DESCRIPTION
## Documentation

- DELTA-4087: https://nicheinc.atlassian.net/browse/DELTA-4087
- Part of the actions-get-pr-metadata migration: DELTA-4083 (new repo), DELTA-4089 (old repo archival, blocked on this and 7 sibling PRs merging first)

## What

Repoint both `Get PR Metadata` references in this repo (`bump-versions.yaml`'s `ACTIONS_GET_CURRENT_PR` anchor, `push-helm-charts.yaml`'s inline `uses:`) from the deprecated `nicheinc/get-pr-metadata` to its full-history clone `nicheinc/actions-get-pr-metadata`.

## Upgrade Targets

| Reference | Current | Target |
| --- | --- | --- |
| `bump-versions.yaml` `ACTIONS_GET_CURRENT_PR` anchor | `nicheinc/get-pr-metadata@v1` | `nicheinc/actions-get-pr-metadata@v1` |
| `push-helm-charts.yaml` inline `uses:` | `nicheinc/get-pr-metadata@v1` | `nicheinc/actions-get-pr-metadata@v1` |

## Notes

`nicheinc/actions-get-pr-metadata` is a byte-identical drop-in: same `v1` tag object SHA (`6f1b28dad390041c2cd183ae32564b0fc37e8392`) and identical `action.yaml` interface as the old repo. No behavior change.

## Test Validation

| Scenario | How validated | Evidence / link | Result | Notes |
| --- | --- | --- | --- | --- |
| Both refs updated to `nicheinc/actions-get-pr-metadata@v1`, zero remaining refs to old slug in either file | `grep -rn "nicheinc/get-pr-metadata"` returns nothing across both files; `git diff` | commit 6187fdc | Pass | |
| Both files remain valid YAML after edit | `ruby -ryaml -e "YAML.load_file(...)"` per file | `OK bump-versions` / `OK push-helm-charts` | Pass | |
| Action resolves and runs correctly under the new slug | Reused from DELTA-4083's live `workflow_dispatch` smoke test on `actions-get-pr-metadata` itself (identical `action.yaml` interface, identical `v1` tag object SHA) | https://github.com/nicheinc/actions-get-pr-metadata/pull/1 | Pass (by inheritance) | Not re-run against this repo's own callers — both are reusable `workflow_call`/composite entry points invoked by other repos' pipelines; triggering a real caller would risk unrelated production side effects for a one-line slug swap |

## Acceptance Criteria

- [ ] Zero references to `nicheinc/get-pr-metadata` remain in this repo's workflows.